### PR TITLE
Add  ability for target on wrist and multiple static camera calibration in two steps

### DIFF
--- a/rct_examples/CMakeLists.txt
+++ b/rct_examples/CMakeLists.txt
@@ -64,14 +64,16 @@ add_dependencies(${PROJECT_NAME}_multi_static_camera ${${PROJECT_NAME}_EXPORTED_
 
 target_link_libraries(${PROJECT_NAME}_multi_static_camera ${catkin_LIBRARIES})
 
-# Executable for demonstrating extrinsic cal of multiple static camera only, moving target functionality
-add_executable(${PROJECT_NAME}_multi_static_camera_only src/tools/multi_static_camera_only_extrinsic.cpp)
+# Executable for demonstrating extrinsic cal of multiple static camera multi step, moving target functionality
+# First it calibrates the cameras to each other then it calibrates the set of camera where there relationship
+# between cameras is fixed but as a whole they can be transformed along with wrist calibration.
+add_executable(${PROJECT_NAME}_multi_static_camera_multi_step src/tools/multi_static_camera_multi_step_extrinsic.cpp)
 
-set_target_properties(${PROJECT_NAME}_multi_static_camera_only PROPERTIES OUTPUT_NAME multi_static_cam_only_extr_cal_ex PREFIX "")
+set_target_properties(${PROJECT_NAME}_multi_static_camera_multi_step PROPERTIES OUTPUT_NAME multi_static_cam_multi_step_extr_cal_ex PREFIX "")
 
-add_dependencies(${PROJECT_NAME}_multi_static_camera_only ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_multi_static_camera_multi_step ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_multi_static_camera_only ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_multi_static_camera_multi_step ${catkin_LIBRARIES})
 
 #Executable for demonstrating intrinsic calibration of a camera
 add_executable(${PROJECT_NAME}_intr src/tools/intrinsic_calibration.cpp)

--- a/rct_examples/CMakeLists.txt
+++ b/rct_examples/CMakeLists.txt
@@ -64,6 +64,15 @@ add_dependencies(${PROJECT_NAME}_multi_static_camera ${${PROJECT_NAME}_EXPORTED_
 
 target_link_libraries(${PROJECT_NAME}_multi_static_camera ${catkin_LIBRARIES})
 
+# Executable for demonstrating extrinsic cal of multiple static camera only, moving target functionality
+add_executable(${PROJECT_NAME}_multi_static_camera_only src/tools/multi_static_camera_only_extrinsic.cpp)
+
+set_target_properties(${PROJECT_NAME}_multi_static_camera_only PROPERTIES OUTPUT_NAME multi_static_cam_only_extr_cal_ex PREFIX "")
+
+add_dependencies(${PROJECT_NAME}_multi_static_camera_only ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(${PROJECT_NAME}_multi_static_camera_only ${catkin_LIBRARIES})
+
 #Executable for demonstrating intrinsic calibration of a camera
 add_executable(${PROJECT_NAME}_intr src/tools/intrinsic_calibration.cpp)
 

--- a/rct_examples/CMakeLists.txt
+++ b/rct_examples/CMakeLists.txt
@@ -93,6 +93,15 @@ add_dependencies(${PROJECT_NAME}_pnp ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catki
 
 target_link_libraries(${PROJECT_NAME}_pnp ${catkin_LIBRARIES})
 
+# Executable demonstrating solving for the pose of a target given multiple camera properties
+add_executable(${PROJECT_NAME}_multi_camera_pnp src/tools/solve_multi_camera_pnp.cpp)
+
+set_target_properties(${PROJECT_NAME}_multi_camera_pnp PROPERTIES OUTPUT_NAME solve_multi_camera_pnp_ex PREFIX "")
+
+add_dependencies(${PROJECT_NAME}_multi_camera_pnp ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(${PROJECT_NAME}_multi_camera_pnp ${catkin_LIBRARIES})
+
 #############
 ## Testing ##
 #############

--- a/rct_examples/launch/multi_static_camera_multi_step_example.launch
+++ b/rct_examples/launch/multi_static_camera_multi_step_example.launch
@@ -2,7 +2,7 @@
   <arg name="data_file"/>
   <arg name="fix_first_camera" default="true"/>
 
-  <node pkg="rct_examples" type="multi_static_cam_only_extr_cal_ex" name="multi_static_camera_only_cal" output="screen">
+  <node pkg="rct_examples" type="multi_static_cam_multi_step_extr_cal_ex" name="multi_static_camera_multi_step_cal" output="screen">
     <rosparam command="load" file="$(arg data_file)"/>
     <param name="fix_first_camera" value="$(arg fix_first_camera)"/>
   </node>

--- a/rct_examples/launch/multi_static_camera_only_example.launch
+++ b/rct_examples/launch/multi_static_camera_only_example.launch
@@ -1,0 +1,9 @@
+<launch>
+  <arg name="data_file"/>
+  <arg name="fix_first_camera" default="true"/>
+
+  <node pkg="rct_examples" type="multi_static_cam_only_extr_cal_ex" name="multi_static_camera_only_cal" output="screen">
+    <rosparam command="load" file="$(arg data_file)"/>
+    <param name="fix_first_camera" value="$(arg fix_first_camera)"/>
+  </node>
+</launch>

--- a/rct_examples/launch/solve_multi_static_camera_pnp_example.launch
+++ b/rct_examples/launch/solve_multi_static_camera_pnp_example.launch
@@ -1,0 +1,7 @@
+<launch>
+  <arg name="data_file"/>
+
+  <node pkg="rct_examples" type="solve_multi_camera_pnp_ex" name="solve_multi_camera_pnp_ex" output="screen">
+    <rosparam command="load" file="$(arg data_file)"/>
+  </node>
+</launch>

--- a/rct_examples/src/examples/camera_on_wrist.cpp
+++ b/rct_examples/src/examples/camera_on_wrist.cpp
@@ -13,6 +13,8 @@
 // This include is used to load images and the associated wrist poses from the data/ directory
 // of this package. It's my only concession to the "self-contained rule".
 #include <rct_ros_tools/data_set.h>
+// This include provide useful print functions for outputing results to terminal
+#include <rct_ros_tools/print_utils.h>
 // This header brings in a tool for finding the target in a given image
 #include <rct_image_tools/image_observation_finder.h>
 // This header brings in he calibration function for 'moving camera' on robot wrist - what we
@@ -132,25 +134,18 @@ int extrinsicWristCameraCalibration()
   // Step 5: Do something with your results. Here I just print the results, but you might want to
   // update a data structure, save to a file, push to a mutable joint or mutable state publisher in
   // ROS. The options are many, and it's up to you. We just try to help solve the problem.
-
-  std::cout << "Did converge?: " << opt_result.converged << "\n";
-  std::cout << "Initial cost?: " << opt_result.initial_cost_per_obs << " error (pixels per dot)\n";
-  std::cout << "Final cost?: " << opt_result.final_cost_per_obs << " error (pixels per dot)\n";
+  rct_ros_tools::printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
+  rct_ros_tools::printNewLine();
 
   // Note: Convergence and low cost does not mean a good calibration. See the calibration primer
   // readme on the main page of this repo.
   Eigen::Affine3d c = opt_result.wrist_to_camera;
+  rct_ros_tools::printTransform(c, "Wrist", "Camera", "WRIST TO CAMERA");
+  rct_ros_tools::printNewLine();
+
   Eigen::Affine3d t = opt_result.base_to_target;
-
-  std::cout << "Wrist To Camera:\n";
-  std::cout << c.matrix() << "\n";
-  std::cout << "Base to Target:\n";
-  std::cout << t.matrix() << "\n";
-
-  std::cout << "--- URDF Format Wrist to Camera---\n";
-  Eigen::Vector3d rpy = c.rotation().eulerAngles(2, 1, 0);
-  std::cout << "xyz=\"" << c.translation()(0) << " " << c.translation()(1) << " " << c.translation()(2) << "\"\n";
-  std::cout << "rpy=\"" << rpy(2) << " " << rpy(1) << " " << rpy(0) << "\"\n";
+  rct_ros_tools::printTransform(t, "Base", "Target", "BASE TO TARGET");
+  rct_ros_tools::printNewLine();
 
   return 0;
 }

--- a/rct_examples/src/tools/camera_on_wrist_extrinsic.cpp
+++ b/rct_examples/src/tools/camera_on_wrist_extrinsic.cpp
@@ -129,20 +129,8 @@ int main(int argc, char** argv)
     //// 1. Record the wrist position
     problem_def.wrist_poses.push_back(data_set.tool_poses[i]);
 
-    //// Create the correspondence pairs
-    rct_optimizations::CorrespondenceSet obs_set;
-    assert(maybe_obs->size() == target.points.size());
-
-    // So for each dot:
-    for (std::size_t j = 0; j < maybe_obs->size(); ++j)
-    {
-      rct_optimizations::Correspondence2D3D pair;
-      pair.in_image = maybe_obs->at(j); // The obs finder and target define their points in the same order!
-      pair.in_target = target.points[j];
-      obs_set.push_back(pair);
-    }
     //// And finally add that to the problem
-    problem_def.image_observations.push_back(obs_set);
+    problem_def.image_observations.push_back(rct_image_tools::getCorrespondenceSet(*maybe_obs, target.points));
   }
 
   // Now we have a defined problem, run optimization:

--- a/rct_examples/src/tools/intrinsic_calibration.cpp
+++ b/rct_examples/src/tools/intrinsic_calibration.cpp
@@ -3,6 +3,7 @@
 #include <rct_optimizations/experimental/camera_intrinsic.h>
 #include "rct_ros_tools/data_set.h"
 #include "rct_ros_tools/parameter_loaders.h"
+#include "rct_ros_tools/print_utils.h"
 
 #include <opencv2/highgui.hpp>
 #include <ros/ros.h>
@@ -42,9 +43,22 @@ void opencvCameraCalibration(const std::vector<rct_optimizations::Correspondence
   std::vector<cv::Mat> tvecs;
   cv::calibrateCamera(object_points, image_points, image_size, camera_matrix, dist_coeffs, rvecs, tvecs);
 
+  std::array<double, 4> intr_values;
+  intr_values[0] = camera_matrix.at<double>(0, 0);
+  intr_values[1] = camera_matrix.at<double>(1, 1);
+  intr_values[2] = camera_matrix.at<double>(0, 2);
+  intr_values[3] = camera_matrix.at<double>(2, 2);
+  rct_ros_tools::printCameraIntrinsics(intr_values, "OpenCV Intrinsics");
+  rct_ros_tools::printNewLine();
 
-  std::cout << "OpenCV Camera Matrix:\n" << camera_matrix << "\n";
-  std::cout << "OpenCV Camera Distortions:\n" << dist_coeffs << "\n";
+  std::array<double, 5> dist_values;
+  dist_values[0] = dist_coeffs.at<double>(0);
+  dist_values[1] = dist_coeffs.at<double>(1);
+  dist_values[2] = dist_coeffs.at<double>(2);
+  dist_values[3] = dist_coeffs.at<double>(3);
+  dist_values[4] = dist_coeffs.at<double>(4);
+  rct_ros_tools::printCameraDistortion(dist_values, "OpenCV Distortion");
+  rct_ros_tools::printNewLine();
 }
 
 int main(int argc, char** argv)
@@ -123,23 +137,22 @@ int main(int argc, char** argv)
   auto opt_result = rct_optimizations::optimize(problem_def);
 
   // Report results
-  std::cout << "---Calibration Complete---\n";
-  std::cout << "Did converge?: " << opt_result.converged << "\n";
-  std::cout << "Initial cost?: " << opt_result.initial_cost_per_obs << "\n";
-  std::cout << "Final cost?: " << opt_result.final_cost_per_obs << "\n";
+  rct_ros_tools::printTitle("Calibration Complete");
+
+  rct_ros_tools::printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
+  rct_ros_tools::printNewLine();
 
   auto new_intr = opt_result.intrinsics;
   auto new_dist = opt_result.distortions;
 
-  std::cout << "New Intr:\nfx = " << new_intr.fx() << "\tfy = " << new_intr.fy() << "\ncx = " << new_intr.cx()
-            << "\tcy = " << new_intr.cy() << "\n\n";
+  rct_ros_tools::printCameraIntrinsics(new_intr.values, "RCT Intrinsics");
+  rct_ros_tools::printNewLine();
 
-  std::cout << "Distortions:\n";
-  std::cout << new_dist[0] << " " << new_dist[1] << " " << new_dist[2] << " " << new_dist[3] << " "
-                           << new_dist[4] << "\n\n";
+  rct_ros_tools::printCameraDistortion(new_dist, "RCT Distortion");
+  rct_ros_tools::printNewLine();
 
   // Also try the OpenCV cameraCalibrate function
-  std::cout << "---OpenCV Calibration---\n";
+  rct_ros_tools::printTitle("OpenCV Calibration");
   opencvCameraCalibration(problem_def.image_observations, data_set.images.front().size(),
                           problem_def.intrinsics_guess);
   return 0;

--- a/rct_examples/src/tools/intrinsic_calibration.cpp
+++ b/rct_examples/src/tools/intrinsic_calibration.cpp
@@ -1,4 +1,5 @@
 #include <rct_image_tools/image_observation_finder.h>
+#include <rct_image_tools/image_utils.h>
 #include <rct_optimizations/eigen_conversions.h>
 #include <rct_optimizations/experimental/camera_intrinsic.h>
 #include "rct_ros_tools/data_set.h"
@@ -118,19 +119,7 @@ int main(int argc, char** argv)
     cv::imshow("points", obs_finder.drawObservations(data_set.images[i], *maybe_obs));
     cv::waitKey();
 
-    rct_optimizations::CorrespondenceSet obs_set;
-
-    assert(maybe_obs->size() == target.points.size());
-    for (std::size_t j = 0; j < maybe_obs->size(); ++j)
-    {
-      rct_optimizations::Correspondence2D3D pair;
-      pair.in_image = maybe_obs->at(j);
-      pair.in_target = target.points[j];
-
-      obs_set.push_back(pair);
-    }
-
-    problem_def.image_observations.push_back(obs_set);
+    problem_def.image_observations.push_back(rct_image_tools::getCorrespondenceSet(*maybe_obs, target.points));
   }
 
   // Run optimization

--- a/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
@@ -65,8 +65,6 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "multi_static_camera_extrinsic");
   ros::NodeHandle pnh("~");
 
-  sleep(10);
-
   int camera_count;
   if (!pnh.getParam("num_of_cameras", camera_count))
   {

--- a/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
@@ -1,6 +1,8 @@
 // Utilities for loading data sets and calib parameters from YAML files via ROS
 #include "rct_ros_tools/data_set.h"
 #include "rct_ros_tools/parameter_loaders.h"
+#include "rct_ros_tools/print_utils.h"
+
 // To find 2D  observations from images
 #include <rct_image_tools/image_observation_finder.h>
 // The calibration function for 'static camera' on robot wrist
@@ -48,23 +50,18 @@ static void reproject(const Eigen::Affine3d& base_to_target,
 
   rct_optimizations::MultiCameraPnPResult r = rct_optimizations::optimize(pb);
   // Report results
-  std::cout << "Did converge?: " << r.converged << "\n";
-  std::cout << "Initial cost?: " << r.initial_cost_per_obs << "\n";
-  std::cout << "Final cost?: " << r.final_cost_per_obs << "\n";
+  rct_ros_tools::printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
+  rct_ros_tools::printNewLine();
 
-  // We want to compute the "positional error" as well
-  // So first we compute the "camera to target" transform based on the calibration...
-  std::cout << "CAMERA 0 TO TARGET\n\n" << camera_to_target.matrix() << "\n";
+  rct_ros_tools::printTransform(camera_to_target, "Camera 0", "Target", "CAMERA 0 TO TARGET");
+  rct_ros_tools::printNewLine();
 
   Eigen::Affine3d result_camera_to_target = base_to_camera[0].inverse() * r.base_to_target;
-  std::cout << "PNP\n" << result_camera_to_target.matrix() << "\n";
+  rct_ros_tools::printTransform(result_camera_to_target, "Camera 0", "Target", "PNP");
+  rct_ros_tools::printNewLine();
 
-  Eigen::Affine3d delta = camera_to_target.inverse() * result_camera_to_target;
-  std::cout << "OTHER S: " << (result_camera_to_target.translation() - camera_to_target.translation()).norm() << "\n";
-  std::cout << "DELTA S: " << delta.translation().norm() << " at " << delta.translation().transpose() << "\n";
-  Eigen::AngleAxisd aa (delta.linear());
-  Eigen::Vector3d rpy = delta.rotation().eulerAngles(2, 1, 0);
-  std::cout << "DELTA A: " << (180.0 * aa.angle() / M_PI) << " and rpy=\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
+  rct_ros_tools::printTransformDiff(camera_to_target, result_camera_to_target, "Camera 0", "Target", "PNP DIFF");
+  rct_ros_tools::printNewLine();
 
   reprojections.clear();
   for (const auto& point_in_target : target.points)
@@ -245,52 +242,27 @@ int main(int argc, char** argv)
       opt_result = rct_optimizations::optimize(problem_def);
 
   // Report results
-  std::cout << "Did converge?: " << opt_result.converged << "\n";
-  std::cout << "Initial cost?: " << opt_result.initial_cost_per_obs << "\n";
-  std::cout << "Final cost?: " << opt_result.final_cost_per_obs << "\n";
+  rct_ros_tools::printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
+  rct_ros_tools::printNewLine();
 
   Eigen::Affine3d t = opt_result.wrist_to_target;
-
-  std::cout << "Wrist to Target:\n";
-  std::cout << t.matrix() << "\n";
-  std::cout << "--- URDF Format Wrist to Target ---\n";
-  Eigen::Vector3d rpy = t.rotation().eulerAngles(2, 1, 0);
-  Eigen::Quaterniond q(t.rotation());
-  std::cout << "xyz  =\"" << t.translation()(0) << " " << t.translation()(1) << " " << t.translation()(2) << "\"\n";
-  std::cout << "rpy  =\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
-  std::cout << "qxyzw=\"" << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << "\"\n";
+  rct_ros_tools::printTransform(t, "Wrist", "Target", "WRIST TO TARGET");
+  rct_ros_tools::printNewLine();
 
   for (std::size_t c = 0; c < num_of_cameras; ++c)
   {
     // Load the data set path from ROS param
     std::string param_base = "camera_" + std::to_string(c);
     t = opt_result.base_to_camera[c];
+    rct_ros_tools::printTransform(t, "Base", " Camera (" + param_base + ")", "BASE TO CAMERA (" + param_base + ")");
+    rct_ros_tools::printNewLine();
 
-    std::cout << "Base to Camera (" + param_base + "):\n";
-    std::cout << t.matrix() << "\n";
-
-    std::cout << "--- URDF Format Base to Camera (" + param_base + ") ---\n";
-    rpy = t.rotation().eulerAngles(2, 1, 0);
-    q = Eigen::Quaterniond(t.rotation());
-    std::cout << "xyz  =\"" << t.translation()(0) << " " << t.translation()(1) << " " << t.translation()(2) << "\"\n";
-    std::cout << "rpy  =\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
-    std::cout << "qxyzw=\"" << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << "\"\n";
-
-    t = opt_result.base_to_camera[0].inverse()  * t;
-    std::cout << "Camera 0 to Camera " << c << ":\n";
-    std::cout << t.matrix() << "\n";
-
-    std::cout << "--- URDF Format Camera 0 to Camera (" + param_base + ") ---\n";
-    rpy = t.rotation().eulerAngles(2, 1, 0);
-    q = Eigen::Quaterniond(t.rotation());
-    std::cout << "xyz  =\"" << t.translation()(0) << " " << t.translation()(1) << " " << t.translation()(2) << "\"\n";
-    std::cout << "rpy  =\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
-    std::cout << "qxyzw=\"" << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << "\"\n";
+    t = opt_result.base_to_camera[0].inverse() * t;
+    rct_ros_tools::printTransform(t, "Camera 0", " Camera " + std::to_string(c), "CAMERA 0 TO CAMERA (" + param_base + ")");
+    rct_ros_tools::printNewLine();
   }
 
-  std::cout << "**************************************************************\n";
-  std::cout << "********************* REPROJECTION ERROR *********************\n";
-  std::cout << "**************************************************************\n";
+  rct_ros_tools::printTitle("REPROJECTION ERROR");
 
   for (std::size_t i = 0; i < maybe_data_set[0]->images.size(); ++i)
   {
@@ -329,9 +301,7 @@ int main(int argc, char** argv)
 
     if (cnt >= 2)
     {
-      std::cout << "***************************\n";
-      std::cout << "**** REPROJECT IMAGE " << i << " ****\n";
-      std::cout << "***************************\n";
+      rct_ros_tools::printTitle("REPROJECT IMAGE " + std::to_string(i));
       reproject(base_to_wrist * opt_result.wrist_to_target, base_to_camera,
                 intr, target, image, corr_set);
     }

--- a/rct_examples/src/tools/multi_static_camera_multi_step_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_multi_step_extrinsic.cpp
@@ -4,6 +4,7 @@
 #include "rct_ros_tools/print_utils.h"
 // To find 2D  observations from images
 #include <rct_image_tools/image_observation_finder.h>
+#include <rct_image_tools/image_utils.h>
 // The calibration function for 'static camera' on robot wrist
 #include <rct_optimizations/extrinsic_multi_static_camera_only.h>
 #include <rct_optimizations/extrinsic_multi_static_camera_wrist_only.h>
@@ -24,23 +25,10 @@ static void reproject(const Eigen::Affine3d& base_to_target,
 {
 
   Eigen::Affine3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections;
-  for (const auto& point_in_target : target.points)
-  {
-    Eigen::Vector3d in_camera = camera_to_target * point_in_target;
-
-    double uv[2];
-    rct_optimizations::projectPoint(intr[0], in_camera.data(), uv);
-
-    reprojections.push_back(cv::Point2d(uv[0], uv[1]));
-  }
+  std::vector<cv::Point2d> reprojections = rct_image_tools::getReprojections(camera_to_target, intr[0], target.points);
 
   cv::Mat before_frame = image.clone();
-
-  for (const auto& pt : reprojections)
-  {
-    cv::circle(before_frame, pt, 3, cv::Scalar(0, 0, 255));
-  }
+  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
 
   rct_optimizations::MultiCameraPnPProblem pb;
   pb.base_to_camera = base_to_camera;
@@ -59,23 +47,9 @@ static void reproject(const Eigen::Affine3d& base_to_target,
   rct_ros_tools::printTransformDiff(camera_to_target, result_camera_to_target, "Camera 0", "Target", "PNP");
   rct_ros_tools::printNewLine();
 
-  reprojections.clear();
-  for (const auto& point_in_target : target.points)
-  {
-    Eigen::Vector3d in_camera = result_camera_to_target * point_in_target;
-
-    double uv[2];
-    rct_optimizations::projectPoint(intr[0], in_camera.data(), uv);
-
-    reprojections.push_back(cv::Point2d(uv[0], uv[1]));
-  }
-
+  reprojections = rct_image_tools::getReprojections(result_camera_to_target, intr[0], target.points);
   cv::Mat after_frame = image.clone();
-
-  for (const auto& pt : reprojections)
-  {
-    cv::circle(after_frame, pt, 3, cv::Scalar(0, 255, 0));
-  }
+  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
 
   cv::imshow("repr_before", before_frame);
   cv::imshow("repr_after", after_frame);

--- a/rct_examples/src/tools/multi_static_camera_only_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_only_extrinsic.cpp
@@ -4,14 +4,14 @@
 // To find 2D  observations from images
 #include <rct_image_tools/image_observation_finder.h>
 // The calibration function for 'static camera' on robot wrist
-#include <rct_optimizations/extrinsic_multi_static_camera.h>
+#include <rct_optimizations/extrinsic_multi_static_camera_only.h>
 
 #include <opencv2/highgui.hpp>
 #include <ros/ros.h>
 
 #include <opencv2/imgproc.hpp>
 #include <rct_optimizations/ceres_math_utilities.h>
-#include <rct_optimizations/experimental/multi_camera_pnp.h>
+#include <rct_optimizations/multi_static_camera_pnp.h>
 
 static void reproject(const Eigen::Affine3d& base_to_target,
                       const std::vector<Eigen::Affine3d>& base_to_camera,
@@ -40,13 +40,13 @@ static void reproject(const Eigen::Affine3d& base_to_target,
     cv::circle(before_frame, pt, 3, cv::Scalar(0, 0, 255));
   }
 
-  rct_optimizations::MultiCameraPnPProblem pb;
+  rct_optimizations::MultiStaticCameraPnPProblem pb;
   pb.base_to_camera = base_to_camera;
   pb.base_to_target_guess = base_to_target;
   pb.image_observations = corr;
   pb.intr = intr;
 
-  rct_optimizations::MultiCameraPnPResult r = rct_optimizations::optimize(pb);
+  rct_optimizations::MultiStaticCameraPnPResult r = rct_optimizations::optimize(pb);
   // Report results
   std::cout << "Did converge?: " << r.converged << "\n";
   std::cout << "Initial cost?: " << r.initial_cost_per_obs << "\n";
@@ -91,10 +91,8 @@ static void reproject(const Eigen::Affine3d& base_to_target,
 
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "multi_static_camera_extrinsic");
+  ros::init(argc, argv, "multi_static_camera_extrinsic_only");
   ros::NodeHandle pnh("~");
-
-  sleep(10);
 
   int camera_count;
   if (!pnh.getParam("num_of_cameras", camera_count))
@@ -104,17 +102,17 @@ int main(int argc, char** argv)
   }
   std::size_t num_of_cameras = camera_count;
 
-  rct_optimizations::ExtrinsicMultiStaticCameraMovingTargetProblem problem_def;
+  rct_optimizations::ExtrinsicMultiStaticCameraOnlyProblem problem_def;
   std::vector<std::string> data_path;
   std::string target_path;
   std::vector<boost::optional<rct_ros_tools::ExtrinsicDataSet> > maybe_data_set;
+  bool fix_first_camera;
 
   data_path.resize(num_of_cameras);
   maybe_data_set.resize(num_of_cameras);
   problem_def.intr.resize(num_of_cameras);
   problem_def.base_to_camera_guess.resize(num_of_cameras);
   problem_def.image_observations.resize(num_of_cameras);
-  problem_def.wrist_poses.resize(num_of_cameras);
   for (std::size_t c = 0; c < num_of_cameras; ++c)
   {
     // Load the data set path from ROS param
@@ -144,7 +142,6 @@ int main(int argc, char** argv)
     if (!rct_ros_tools::loadIntrinsics(pnh, param_name, problem_def.intr[c]))
     {
       ROS_WARN("Unable to load camera intrinsics from the '%s' parameter struct", param_name.c_str());
-      return 1;
     }
 
     param_name = param_base + "base_to_camera_guess";
@@ -152,14 +149,7 @@ int main(int argc, char** argv)
     if (!rct_ros_tools::loadPose(pnh, param_name, problem_def.base_to_camera_guess[c]))
     {
       ROS_WARN("Unable to load guess for base to camera from the '%s' parameter struct", param_name.c_str());
-      return 1;
     }
-  }
-
-  if (!rct_ros_tools::loadPose(pnh, "wrist_to_target_guess", problem_def.wrist_to_target_guess))
-  {
-    ROS_WARN_STREAM("Unable to load guess for wrist to target from the 'wrist_to_target_guess' parameter struct");
-    return 1;
   }
 
   if (!pnh.getParam("target_path", target_path))
@@ -168,22 +158,27 @@ int main(int argc, char** argv)
     return 1;
   }
 
+  if (!pnh.getParam("fix_first_camera", fix_first_camera))
+  {
+    ROS_ERROR("Must set '%s' parameter", "fix_first_camera");
+    return 1;
+  }
+
   // Load target definition from parameter server. Target will get
   // reset if such a parameter was set.
-  rct_image_tools::ModifiedCircleGridTarget target;
+  rct_image_tools::ModifiedCircleGridTarget target(5, 5, 0.015);
   if (!rct_ros_tools::loadTarget(target_path, target))
   {
     ROS_WARN_STREAM("Unable to load target file from the 'target_path' parameter");
-    return 1;
   }
 
   // Lets create a class that will search for the target in our raw images.
   rct_image_tools::ModifiedCircleGridObservationFinder obs_finder(target);
 
-  std::vector<std::vector<bool>> found_images;
+  std::vector<bool> found_images;
   std::vector<std::vector<rct_optimizations::CorrespondenceSet>> all_image_observations;
 
-  found_images.resize(num_of_cameras);
+  found_images.resize(maybe_data_set[0]->images.size());
   all_image_observations.resize(num_of_cameras);
   for (std::size_t c = 0; c < num_of_cameras; ++c)
   {
@@ -193,10 +188,12 @@ int main(int argc, char** argv)
     // Finally, we need to process our images into correspondence sets: for each dot in the
     // target this will be where that dot is in the target and where it was seen in the image.
     // Repeat for each image. We also tell where the wrist was when the image was taken.
-    found_images[c].resize(data_set.images.size());
     all_image_observations[c].resize(data_set.images.size());
     for (std::size_t i = 0; i < data_set.images.size(); ++i)
     {
+      if (c == 0)
+        found_images[i] = true;
+
       // Try to find the circle grid in this image:
       auto maybe_obs = obs_finder.findObservations(data_set.images[i]);
       if (!maybe_obs)
@@ -204,7 +201,7 @@ int main(int argc, char** argv)
         ROS_WARN_STREAM("Unable to find the circle grid in image: " << i);
         cv::imshow("points", data_set.images[i]);
         cv::waitKey();
-        found_images[c][i] = false;
+        found_images[i] = false;
         continue;
       }
       else
@@ -213,12 +210,6 @@ int main(int argc, char** argv)
         cv::imshow("points", obs_finder.drawObservations(data_set.images[i], *maybe_obs));
         cv::waitKey();
       }
-      // cache if target found
-      found_images[c][i] = true;
-
-      // So for each image we need to:
-      //// 1. Record the wrist position
-      problem_def.wrist_poses[c].push_back(data_set.tool_poses[i]);
 
       //// Create the correspondence pairs
       rct_optimizations::CorrespondenceSet obs_set;
@@ -235,13 +226,34 @@ int main(int argc, char** argv)
       }
       //// And finally add that to the problem
       all_image_observations[c][i] = obs_set;
-      problem_def.image_observations[c].push_back(obs_set);
     }
   }
 
+  Eigen::Affine3d wrist_to_target;
+  wrist_to_target.setIdentity();
+  if (pnh.hasParam("wrist_to_target_guess") && !rct_ros_tools::loadPose(pnh, "wrist_to_target_guess", wrist_to_target))
+  {
+    ROS_WARN_STREAM("Unable to load guess for wrist to target from the 'wrist_to_target_guess' parameter struct");
+  }
+
+  std::vector<cv::Mat> images;
+  for (std::size_t i = 0; i < found_images.size(); ++i)
+  {
+    if (found_images[i])
+    {
+      images.push_back(maybe_data_set[0]->images[i]);
+      problem_def.base_to_target_guess.push_back(maybe_data_set[0]->tool_poses[i] * wrist_to_target);
+      for (std::size_t c = 0; c < num_of_cameras; ++c)
+      {
+        problem_def.image_observations[c].push_back(all_image_observations[c][i]);
+      }
+    }
+  }
+
+  problem_def.fix_first_camera = fix_first_camera;
 
   // Run optimization
-  rct_optimizations::ExtrinsicMultiStaticCameraMovingTargetResult
+  rct_optimizations::ExtrinsicMultiStaticCameraOnlyResult
       opt_result = rct_optimizations::optimize(problem_def);
 
   // Report results
@@ -249,31 +261,20 @@ int main(int argc, char** argv)
   std::cout << "Initial cost?: " << opt_result.initial_cost_per_obs << "\n";
   std::cout << "Final cost?: " << opt_result.final_cost_per_obs << "\n";
 
-  Eigen::Affine3d t = opt_result.wrist_to_target;
-
-  std::cout << "Wrist to Target:\n";
-  std::cout << t.matrix() << "\n";
-  std::cout << "--- URDF Format Wrist to Target ---\n";
-  Eigen::Vector3d rpy = t.rotation().eulerAngles(2, 1, 0);
-  Eigen::Quaterniond q(t.rotation());
-  std::cout << "xyz  =\"" << t.translation()(0) << " " << t.translation()(1) << " " << t.translation()(2) << "\"\n";
-  std::cout << "rpy  =\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
-  std::cout << "qxyzw=\"" << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << "\"\n";
-
   for (std::size_t c = 0; c < num_of_cameras; ++c)
   {
     // Load the data set path from ROS param
     std::string param_base = "camera_" + std::to_string(c);
-    t = opt_result.base_to_camera[c];
+    Eigen::Affine3d t = opt_result.base_to_camera[c];
 
     std::cout << "Base to Camera (" + param_base + "):\n";
     std::cout << t.matrix() << "\n";
 
     std::cout << "--- URDF Format Base to Camera (" + param_base + ") ---\n";
-    rpy = t.rotation().eulerAngles(2, 1, 0);
-    q = Eigen::Quaterniond(t.rotation());
-    std::cout << "xyz  =\"" << t.translation()(0) << " " << t.translation()(1) << " " << t.translation()(2) << "\"\n";
-    std::cout << "rpy  =\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
+    Eigen::Vector3d rpy = t.rotation().eulerAngles(2, 1, 0);
+    Eigen::Quaterniond q(t.rotation());
+    std::cout << "xyz=\"" << t.translation()(0) << " " << t.translation()(1) << " " << t.translation()(2) << "\"\n";
+    std::cout << "rpy=\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
     std::cout << "qxyzw=\"" << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << "\"\n";
 
     t = opt_result.base_to_camera[0].inverse()  * t;
@@ -292,49 +293,31 @@ int main(int argc, char** argv)
   std::cout << "********************* REPROJECTION ERROR *********************\n";
   std::cout << "**************************************************************\n";
 
-  for (std::size_t i = 0; i < maybe_data_set[0]->images.size(); ++i)
+  for (std::size_t i = 0; i < opt_result.base_to_target.size(); ++i)
   {
     std::vector<rct_optimizations::CorrespondenceSet> corr_set;
     std::vector<Eigen::Affine3d> base_to_camera;
-    Eigen::Affine3d base_to_wrist;
+    Eigen::Affine3d base_to_target;
     std::vector<rct_optimizations::CameraIntrinsics> intr;
-    cv::Mat image;
 
     corr_set.reserve(num_of_cameras);
     base_to_camera.reserve(num_of_cameras);
     intr.reserve(num_of_cameras);
 
-    base_to_wrist = maybe_data_set[0]->tool_poses[i];
+    base_to_target = opt_result.base_to_target[i];
 
-    std::size_t cnt = 0;
     for (std::size_t c = 0; c < num_of_cameras; ++c)
     {
-      if (found_images[c][i])
-      {
-        base_to_camera.push_back(opt_result.base_to_camera[c]);
-        intr.push_back(problem_def.intr[c]);
-        corr_set.push_back(all_image_observations[c][i]);
-        if (cnt == 0)
-        {
-          image = maybe_data_set[c]->images[i];
-        }
-
-        ++cnt;
-      }
-      else
-      {
-        continue;
-      }
+      base_to_camera.push_back(opt_result.base_to_camera[c]);
+      intr.push_back(problem_def.intr[c]);
+      corr_set.push_back(problem_def.image_observations[c][i]);
     }
 
-    if (cnt >= 2)
-    {
-      std::cout << "***************************\n";
-      std::cout << "**** REPROJECT IMAGE " << i << " ****\n";
-      std::cout << "***************************\n";
-      reproject(base_to_wrist * opt_result.wrist_to_target, base_to_camera,
-                intr, target, image, corr_set);
-    }
+    std::cout << "***************************\n";
+    std::cout << "**** REPROJECT IMAGE " << i << " ****\n";
+    std::cout << "***************************\n";
+    reproject(base_to_target, base_to_camera,
+              intr, target, images[i], corr_set);
   }
 
   return 0;

--- a/rct_examples/src/tools/solve_multi_camera_pnp.cpp
+++ b/rct_examples/src/tools/solve_multi_camera_pnp.cpp
@@ -69,8 +69,6 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "solve_multi_camera_pnp_ex", ros::init_options::AnonymousName);
   ros::NodeHandle pnh("~");
 
-  sleep(10);
-
   int camera_count;
   if (!pnh.getParam("num_of_cameras", camera_count))
   {

--- a/rct_examples/src/tools/solve_multi_camera_pnp.cpp
+++ b/rct_examples/src/tools/solve_multi_camera_pnp.cpp
@@ -1,0 +1,259 @@
+/*
+ * This file is meant to provide an example of solving the PnP problem using OpenCV's functions and with Ceres
+ * cost functions. This is a handy utility to have for doing stuff like quantifying the error of the system
+ * after calibration
+ */
+
+#include <ros/ros.h>
+#include <opencv2/highgui.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <rct_image_tools/image_observation_finder.h>
+#include <rct_optimizations/experimental/multi_camera_pnp.h>
+#include <rct_optimizations/ceres_math_utilities.h>
+#include <rct_ros_tools/parameter_loaders.h>
+#include <rct_ros_tools/data_set.h>
+
+static void reproject(const Eigen::Affine3d& base_to_target,
+                      const std::vector<Eigen::Affine3d>& base_to_camera,
+                      const std::vector<rct_optimizations::CameraIntrinsics>& intr,
+                      const rct_image_tools::ModifiedCircleGridTarget& target,
+                      const cv::Mat& image,
+                      const std::vector<rct_optimizations::CorrespondenceSet>& corr)
+{
+
+  Eigen::Affine3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
+  std::vector<cv::Point2d> reprojections;
+  for (const auto& point_in_target : target.points)
+  {
+    Eigen::Vector3d in_camera = camera_to_target * point_in_target;
+
+    double uv[2];
+    rct_optimizations::projectPoint(intr[0], in_camera.data(), uv);
+
+    reprojections.push_back(cv::Point2d(uv[0], uv[1]));
+  }
+
+  cv::Mat before_frame = image.clone();
+
+  for (const auto& pt : reprojections)
+  {
+    cv::circle(before_frame, pt, 3, cv::Scalar(0, 0, 255));
+  }
+
+  rct_optimizations::MultiCameraPnPProblem pb;
+  pb.base_to_camera = base_to_camera;
+  pb.base_to_target_guess = base_to_target;
+  pb.image_observations = corr;
+  pb.intr = intr;
+
+  rct_optimizations::MultiCameraPnPResult r = rct_optimizations::optimize(pb);
+  // Report results
+  std::cout << "Did converge?: " << r.converged << "\n";
+  std::cout << "Initial cost?: " << r.initial_cost_per_obs << "\n";
+  std::cout << "Final cost?: " << r.final_cost_per_obs << "\n";
+
+  // We want to compute the "positional error" as well
+  // So first we compute the "camera to target" transform based on the calibration...
+  std::cout << "BASE TO TARGET\n\n" << base_to_target.matrix() << "\n";
+  std::cout << "--- URDF Format Base to Target ---\n";
+  Eigen::Vector3d rpy = base_to_target.rotation().eulerAngles(2, 1, 0);
+  Eigen::Quaterniond q(base_to_target.rotation());
+  std::cout << "xyz=\"" << base_to_target.translation()(0) << " " << base_to_target.translation()(1) << " " << base_to_target.translation()(2) << "\"\n";
+  std::cout << "rpy=\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
+  std::cout << "qxyzw=\"" << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << "\"\n\n";
+
+  std::cout << "PNP\n" << r.base_to_target.matrix() << "\n";
+  std::cout << "--- URDF Format Base to Target ---\n";
+  rpy = r.base_to_target.rotation().eulerAngles(2, 1, 0);
+  q = Eigen::Quaterniond(r.base_to_target.rotation());
+  std::cout << "xyz=\"" << r.base_to_target.translation()(0) << " " << r.base_to_target.translation()(1) << " " << r.base_to_target.translation()(2) << "\"\n";
+  std::cout << "rpy=\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
+  std::cout << "qxyzw=\"" << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << "\"\n\n";
+
+  Eigen::Affine3d delta = base_to_target.inverse() * r.base_to_target;
+  std::cout << "OTHER S: " << (r.base_to_target.translation() - base_to_target.translation()).norm() << "\n";
+  std::cout << "DELTA S: " << delta.translation().norm() << " at " << delta.translation().transpose() << "\n";
+  Eigen::AngleAxisd aa (delta.linear());
+  rpy = delta.rotation().eulerAngles(2, 1, 0);
+
+  std::cout << "DELTA A: " << (180.0 * aa.angle() / M_PI) << " and rpy=\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
+
+  reprojections.clear();
+  Eigen::Affine3d result_camera_to_target = base_to_camera[0].inverse() * r.base_to_target;
+  for (const auto& point_in_target : target.points)
+  {
+    Eigen::Vector3d in_camera = result_camera_to_target * point_in_target;
+
+    double uv[2];
+    rct_optimizations::projectPoint(intr[0], in_camera.data(), uv);
+
+    reprojections.push_back(cv::Point2d(uv[0], uv[1]));
+  }
+
+  cv::Mat after_frame = image.clone();
+
+  for (const auto& pt : reprojections)
+  {
+    cv::circle(after_frame, pt, 3, cv::Scalar(0, 255, 0));
+  }
+
+  cv::imshow("repr_before", before_frame);
+  cv::imshow("repr_after", after_frame);
+  cv::waitKey();
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "solve_multi_camera_pnp_ex", ros::init_options::AnonymousName);
+  ros::NodeHandle pnh("~");
+
+  sleep(10);
+
+  int camera_count;
+  if (!pnh.getParam("num_of_cameras", camera_count))
+  {
+    ROS_ERROR("Must set '%s' parameter", "num_of_cameras");
+    return 1;
+  }
+  std::size_t num_of_cameras = camera_count;
+
+  std::vector<Eigen::Affine3d> base_to_camera;
+  std::vector<rct_optimizations::CameraIntrinsics> intr;
+  std::vector<std::string> data_path;
+  std::string target_path;
+  std::vector<boost::optional<rct_ros_tools::ExtrinsicDataSet> > maybe_data_set;
+
+  data_path.resize(num_of_cameras);
+  maybe_data_set.resize(num_of_cameras);
+  intr.resize(num_of_cameras);
+  base_to_camera.resize(num_of_cameras);
+  for (std::size_t c = 0; c < num_of_cameras; ++c)
+  {
+    // Load the data set path from ROS param
+    std::string param_base = "camera_" + std::to_string(c) + "/";
+    std::string param_name = param_base + "data_path";
+    if (!pnh.getParam(param_name, data_path[c]))
+    {
+      ROS_ERROR("Must set '%s' parameter", param_name.c_str());
+      return 1;
+    }
+
+    // Attempt to load the data set from the specified path
+    maybe_data_set[c] = rct_ros_tools::parseFromFile(data_path[c]);
+    if (!maybe_data_set[c])
+    {
+      ROS_ERROR_STREAM("Failed to parse data set from path = " << data_path[c]);
+      return 2;
+    }
+
+    // Load the camera intrinsics from the parameter server. Intr will get
+    // reset if such a parameter was set
+    param_name = param_base + "intrinsics";
+    intr[c].fx() = 1411.0;
+    intr[c].fy() = 1408.0;
+    intr[c].cx() = 807.2;
+    intr[c].cy() = 615.0;
+    if (!rct_ros_tools::loadIntrinsics(pnh, param_name, intr[c]))
+    {
+      ROS_WARN("Unable to load camera intrinsics from the '%s' parameter struct", param_name.c_str());
+    }
+
+    param_name = param_base + "base_to_camera";
+    // Our 'base to camera guess': A camera off to the side, looking at a point centered in front of the robot
+    if (!rct_ros_tools::loadPose(pnh, param_name, base_to_camera[c]))
+    {
+      ROS_WARN("Unable to load guess for base to camera from the '%s' parameter struct", param_name.c_str());
+    }
+  }
+
+  if (!pnh.getParam("target_path", target_path))
+  {
+    ROS_ERROR("Must set '%s' parameter", "target_path");
+    return 1;
+  }
+
+  // Load target definition from parameter server. Target will get
+  // reset if such a parameter was set.
+  rct_image_tools::ModifiedCircleGridTarget target(5, 5, 0.015);
+  if (!rct_ros_tools::loadTarget(target_path, target))
+  {
+    ROS_WARN_STREAM("Unable to load target file from the 'target_path' parameter");
+  }
+
+  // Lets create a class that will search for the target in our raw images.
+  rct_image_tools::ModifiedCircleGridObservationFinder obs_finder(target);
+  std::vector<bool> found_images;
+  std::vector<std::vector<rct_optimizations::CorrespondenceSet>> all_image_observations;
+
+  found_images.resize(maybe_data_set[0]->images.size());
+  all_image_observations.resize(num_of_cameras);
+  for (std::size_t c = 0; c < num_of_cameras; ++c)
+  {
+    // We know it exists, so define a helpful alias
+    const rct_ros_tools::ExtrinsicDataSet& data_set = *maybe_data_set[c];
+
+    // Finally, we need to process our images into correspondence sets: for each dot in the
+    // target this will be where that dot is in the target and where it was seen in the image.
+    // Repeat for each image. We also tell where the wrist was when the image was taken.
+    all_image_observations[c].resize(data_set.images.size());
+    for (std::size_t i = 0; i < data_set.images.size(); ++i)
+    {
+      if (c == 0)
+        found_images[i] = true;
+
+      // Try to find the circle grid in this image:
+      auto maybe_obs = obs_finder.findObservations(data_set.images[i]);
+      if (!maybe_obs)
+      {
+        ROS_WARN_STREAM("Unable to find the circle grid in image: " << i);
+        cv::imshow("points", data_set.images[i]);
+        cv::waitKey();
+        found_images[i] = false;
+        continue;
+      }
+      else
+      {
+        // Show the points we detected
+        cv::imshow("points", obs_finder.drawObservations(data_set.images[i], *maybe_obs));
+        cv::waitKey();
+      }
+
+      //// Create the correspondence pairs
+      rct_optimizations::CorrespondenceSet obs_set;
+      assert(maybe_obs->size() == target.points.size());
+
+      // So for each dot:
+      for (std::size_t j = 0; j < maybe_obs->size(); ++j)
+      {
+        rct_optimizations::Correspondence2D3D pair;
+        pair.in_image = maybe_obs->at(j); // The obs finder and target define their points in the same order!
+        pair.in_target = target.points[j];
+
+        obs_set.push_back(pair);
+      }
+      //// And finally add that to the problem
+      all_image_observations[c][i] = obs_set;
+    }
+  }
+
+  for (std::size_t i = 0; i < found_images.size(); ++i)
+  {
+    if (found_images[i])
+    {
+      std::vector<rct_optimizations::CorrespondenceSet> corr_set;
+      for (std::size_t c = 0; c < num_of_cameras; ++c)
+      {
+        corr_set.push_back(all_image_observations[c][i]);
+      }
+
+      std::cout << "***************************\n";
+      std::cout << "**** REPROJECT IMAGE " << i << " ****\n";
+      std::cout << "***************************\n";
+      reproject(maybe_data_set[0]->tool_poses[i], base_to_camera,
+                intr, target, maybe_data_set[0]->images[i], corr_set);
+    }
+  }
+}
+

--- a/rct_examples/src/tools/solve_multi_camera_pnp.cpp
+++ b/rct_examples/src/tools/solve_multi_camera_pnp.cpp
@@ -10,6 +10,7 @@
 #include <opencv2/imgproc.hpp>
 
 #include <rct_image_tools/image_observation_finder.h>
+#include <rct_image_tools/image_utils.h>
 #include <rct_optimizations/experimental/multi_camera_pnp.h>
 #include <rct_optimizations/ceres_math_utilities.h>
 #include <rct_ros_tools/parameter_loaders.h>
@@ -25,23 +26,10 @@ static void reproject(const Eigen::Affine3d& base_to_target,
 {
 
   Eigen::Affine3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections;
-  for (const auto& point_in_target : target.points)
-  {
-    Eigen::Vector3d in_camera = camera_to_target * point_in_target;
-
-    double uv[2];
-    rct_optimizations::projectPoint(intr[0], in_camera.data(), uv);
-
-    reprojections.push_back(cv::Point2d(uv[0], uv[1]));
-  }
+  std::vector<cv::Point2d> reprojections = rct_image_tools::getReprojections(camera_to_target, intr[0], target.points);
 
   cv::Mat before_frame = image.clone();
-
-  for (const auto& pt : reprojections)
-  {
-    cv::circle(before_frame, pt, 3, cv::Scalar(0, 0, 255));
-  }
+  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
 
   rct_optimizations::MultiCameraPnPProblem pb;
   pb.base_to_camera = base_to_camera;
@@ -65,24 +53,11 @@ static void reproject(const Eigen::Affine3d& base_to_target,
   rct_ros_tools::printTransformDiff(base_to_target, r.base_to_target, "Base", "Target", "PNP Diff");
   rct_ros_tools::printNewLine();
 
-  reprojections.clear();
   Eigen::Affine3d result_camera_to_target = base_to_camera[0].inverse() * r.base_to_target;
-  for (const auto& point_in_target : target.points)
-  {
-    Eigen::Vector3d in_camera = result_camera_to_target * point_in_target;
-
-    double uv[2];
-    rct_optimizations::projectPoint(intr[0], in_camera.data(), uv);
-
-    reprojections.push_back(cv::Point2d(uv[0], uv[1]));
-  }
+  reprojections = rct_image_tools::getReprojections(result_camera_to_target, intr[0], target.points);
 
   cv::Mat after_frame = image.clone();
-
-  for (const auto& pt : reprojections)
-  {
-    cv::circle(after_frame, pt, 3, cv::Scalar(0, 255, 0));
-  }
+  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
 
   cv::imshow("repr_before", before_frame);
   cv::imshow("repr_after", after_frame);

--- a/rct_examples/src/tools/solve_pnp.cpp
+++ b/rct_examples/src/tools/solve_pnp.cpp
@@ -9,6 +9,7 @@
 #include <opencv2/calib3d/calib3d.hpp>
 
 #include <rct_image_tools/image_observation_finder.h>
+#include <rct_image_tools/image_utils.h>
 #include <rct_optimizations/experimental/pnp.h>
 #include <rct_ros_tools/parameter_loaders.h>
 #include <rct_ros_tools/print_utils.h>
@@ -103,17 +104,7 @@ int main(int argc, char** argv)
   rct_optimizations::PnPProblem params;
   params.intr = intr;
   params.camera_to_target_guess = guess;
-
-  rct_optimizations::CorrespondenceSet correspondences;
-  for (std::size_t i = 0; i < maybe_obs->size(); ++i)
-  {
-    rct_optimizations::Correspondence2D3D pair;
-    pair.in_image = (*maybe_obs)[i];
-    pair.in_target = target.points[i];
-    correspondences.push_back(pair);
-  }
-
-  params.correspondences = correspondences;
+  params.correspondences = rct_image_tools::getCorrespondenceSet(*maybe_obs, target.points);
 
   rct_optimizations::PnPResult pnp_result = rct_optimizations::optimize(params);
 

--- a/rct_examples/src/tools/solve_pnp.cpp
+++ b/rct_examples/src/tools/solve_pnp.cpp
@@ -11,6 +11,7 @@
 #include <rct_image_tools/image_observation_finder.h>
 #include <rct_optimizations/experimental/pnp.h>
 #include <rct_ros_tools/parameter_loaders.h>
+#include <rct_ros_tools/print_utils.h>
 
 static Eigen::Affine3d solveCVPnP(const rct_optimizations::CameraIntrinsics& intr,
                                   const rct_image_tools::ModifiedCircleGridTarget& target,
@@ -24,7 +25,8 @@ static Eigen::Affine3d solveCVPnP(const rct_optimizations::CameraIntrinsics& int
   cam_matrix.at<double>(0, 2) = intr.cx();
   cam_matrix.at<double>(1, 2) = intr.cy();
 
-  std::cout << "Camera matrix:\n" << cam_matrix << "\n";
+  rct_ros_tools::printCameraIntrinsics(intr.values, "Camera Intrinsics");
+  rct_ros_tools::printNewLine();
 
   std::vector<cv::Point2d> image_points;
   for (const auto o : obs)
@@ -37,19 +39,14 @@ static Eigen::Affine3d solveCVPnP(const rct_optimizations::CameraIntrinsics& int
   cv::Mat rvec (3, 1, cv::DataType<double>::type);
   cv::Mat tvec (3, 1, cv::DataType<double>::type);
   cv::solvePnP(target_points, image_points, cam_matrix, cv::noArray(), rvec, tvec);
-  std::cout << "rvec: " << rvec << "\n";
-  std::cout << "tvec: " << tvec << "\n";
-
-  Eigen::Affine3d result;
-  result.setIdentity();
-  result.translation() = Eigen::Vector3d(tvec.at<double>(0, 0), tvec.at<double>(1, 0), tvec.at<double>(2, 0));
 
   Eigen::Vector3d rr (Eigen::Vector3d(rvec.at<double>(0, 0), rvec.at<double>(1, 0), rvec.at<double>(2, 0)));
-  std::cout << "RR " << rr << "\n";
+  Eigen::Affine3d result(Eigen::AngleAxisd(rr.norm(), rr.normalized()));
+  result.translation() = Eigen::Vector3d(tvec.at<double>(0, 0), tvec.at<double>(1, 0), tvec.at<double>(2, 0));
 
-  Eigen::AngleAxisd rot (rr.norm(), rr.normalized());
+  rct_ros_tools::printTransform(result, "Camera", "Target", "OpenCV solvePNP");
+  rct_ros_tools::printNewLine();
 
-  result.linear() = rot.toRotationMatrix();
   return result;
 }
 
@@ -97,8 +94,7 @@ int main(int argc, char** argv)
   cv::waitKey();
 
   // Solve with OpenCV
-  Eigen::Affine3d cv_pose = solveCVPnP(intr, target, *maybe_obs);
-  std::cout << "CV_POSE\n" << cv_pose.matrix() << "\n";
+  solveCVPnP(intr, target, *maybe_obs);
 
   // Solve with some native RCT function (for learning)
   Eigen::Affine3d guess = Eigen::Affine3d::Identity();
@@ -120,7 +116,12 @@ int main(int argc, char** argv)
   params.correspondences = correspondences;
 
   rct_optimizations::PnPResult pnp_result = rct_optimizations::optimize(params);
-  std::cout << "RCT_POSE\n" << pnp_result.camera_to_target.matrix() << "\n";
+
+  rct_ros_tools::printOptResults(pnp_result.converged, pnp_result.initial_cost_per_obs, pnp_result.final_cost_per_obs);
+  rct_ros_tools::printNewLine();
+
+  rct_ros_tools::printTransform(pnp_result.camera_to_target, "Camera", "Target", "RCT CAMERA TO TARGET");
+  rct_ros_tools::printNewLine();
 
   return 0;
 }

--- a/rct_examples/src/tools/static_camera_extrinsic.cpp
+++ b/rct_examples/src/tools/static_camera_extrinsic.cpp
@@ -132,21 +132,8 @@ int main(int argc, char** argv)
     //// 1. Record the wrist position
     problem_def.wrist_poses.push_back(data_set.tool_poses[i]);
 
-    //// Create the correspondence pairs
-    rct_optimizations::CorrespondenceSet obs_set;
-    assert(maybe_obs->size() == target.points.size());
-
-    // So for each dot:
-    for (std::size_t j = 0; j < maybe_obs->size(); ++j)
-    {
-      rct_optimizations::Correspondence2D3D pair;
-      pair.in_image = maybe_obs->at(j); // The obs finder and target define their points in the same order!
-      pair.in_target = target.points[j];
-
-      obs_set.push_back(pair);
-    }
     //// And finally add that to the problem
-    problem_def.image_observations.push_back(obs_set);
+    problem_def.image_observations.push_back(rct_image_tools::getCorrespondenceSet(*maybe_obs, target.points));
   }
 
   // Run optimization

--- a/rct_image_tools/include/rct_image_tools/image_observation_finder.h
+++ b/rct_image_tools/include/rct_image_tools/image_observation_finder.h
@@ -27,6 +27,8 @@ public:
    */
   cv::Mat drawObservations(const cv::Mat& image, const std::vector<Eigen::Vector2d>& observations) const;
 
+  const ModifiedCircleGridTarget& target() const { return target_; }
+
 private:
   ModifiedCircleGridTarget target_;
 };

--- a/rct_image_tools/include/rct_image_tools/image_utils.h
+++ b/rct_image_tools/include/rct_image_tools/image_utils.h
@@ -3,6 +3,7 @@
 #include <opencv2/imgproc.hpp>
 #include <Eigen/Dense>
 #include <rct_optimizations/ceres_math_utilities.h>
+#include <rct_image_tools/image_observation_finder.h>
 
 namespace rct_image_tools
 {
@@ -51,7 +52,53 @@ void drawReprojections(const std::vector<cv::Point2d> &reprojections,
   }
 }
 
+/**
+ * @brief Get the correspondence set given observations in the image and 3d target points
+ * @param observations Observation in the image frame
+ * @param target_points The 3d target points
+ * @return The correspondence set
+ */
+inline
+rct_optimizations::CorrespondenceSet getCorrespondenceSet(const std::vector<Eigen::Vector2d> &observations, const std::vector<Eigen::Vector3d> &target_points)
+{
+  rct_optimizations::CorrespondenceSet obs_set;
 
+  //// Create the correspondence pairs
+  assert(observations.size() == target_points.size());
+
+  // So for each dot:
+  for (std::size_t j = 0; j < observations.size(); ++j)
+  {
+    rct_optimizations::Correspondence2D3D pair;
+    pair.in_image = observations.at(j); // The obs finder and target define their points in the same order!
+    pair.in_target = target_points.at(j);
+
+    obs_set.push_back(pair);
+  }
+
+  return obs_set;
+}
+
+/**
+ * @brief Get a correspondence set given the observation finder and an image
+ * @param obs_finder The observation finder
+ * @param image The image to search for observation
+ * @return A correspondence set
+ */
+inline
+rct_optimizations::CorrespondenceSet getCorrespondenceSet(const rct_image_tools::ModifiedCircleGridObservationFinder &obs_finder, const cv::Mat& image)
+{
+  const rct_image_tools::ModifiedCircleGridTarget& target = obs_finder.target();
+  auto maybe_obs = obs_finder.findObservations(image);
+
+  rct_optimizations::CorrespondenceSet obs_set;
+  if (maybe_obs)
+  {
+    obs_set = getCorrespondenceSet(*maybe_obs, target.points);
+  }
+
+  return obs_set;
+}
 
 }
 #endif // RCT_IMAGE_UTILS_H

--- a/rct_image_tools/include/rct_image_tools/image_utils.h
+++ b/rct_image_tools/include/rct_image_tools/image_utils.h
@@ -1,0 +1,57 @@
+#ifndef RCT_IMAGE_UTILS_H
+#define RCT_IMAGE_UTILS_H
+#include <opencv2/imgproc.hpp>
+#include <Eigen/Dense>
+#include <rct_optimizations/ceres_math_utilities.h>
+
+namespace rct_image_tools
+{
+
+/**
+ * @brief Get the uv coordinates of a point reprojected into the image frame
+ * @param camera_to_target The transformation from the camera frame to the target frame
+ * @param intr The intrinsic values of the camera
+ * @param target_points A vector of target points
+ * @return A vector of uv values in the image frame
+ */
+inline
+std::vector<cv::Point2d> getReprojections(const Eigen::Affine3d &camera_to_target,
+                                          const rct_optimizations::CameraIntrinsics &intr,
+                                          const std::vector<Eigen::Vector3d> &target_points)
+{
+  std::vector<cv::Point2d> reprojections;
+  for (const auto& point_in_target : target_points)
+  {
+    Eigen::Vector3d in_camera = camera_to_target * point_in_target;
+
+    double uv[2];
+    rct_optimizations::projectPoint(intr, in_camera.data(), uv);
+
+    reprojections.push_back(cv::Point2d(uv[0], uv[1]));
+  }
+  return reprojections;
+}
+
+/**
+ * @brief Draw a set of reprojections on an image
+ * @param reprojections A vector of reprojections to be drawn on the image
+ * @param size The size of circle to drawn
+ * @param color The color of the circle drawn
+ * @param image The image to draw the reprojections on
+ */
+inline
+void drawReprojections(const std::vector<cv::Point2d> &reprojections,
+                       double size,
+                       cv::Scalar color,
+                       cv::Mat &image)
+{
+  for (const auto& pt : reprojections)
+  {
+    cv::circle(image, pt, size, color);
+  }
+}
+
+
+
+}
+#endif // RCT_IMAGE_UTILS_H

--- a/rct_image_tools/src/rct_image_tools/image_observation_finder.cpp
+++ b/rct_image_tools/src/rct_image_tools/image_observation_finder.cpp
@@ -300,9 +300,8 @@ static bool extractModifiedCircleGrid(const cv::Mat& image, const rct_image_tool
                                       ObservationPoints& observation_points)
 {
   PARAMS detector_params;
-  detector_params.maxArea = image.cols * image.rows;
 
-  cv::Ptr<DETECTOR_PTR> detector_ptr = DETECTOR::create();
+  cv::Ptr<DETECTOR_PTR> detector_ptr = DETECTOR::create(detector_params);
 
   bool flipped = false;
 

--- a/rct_image_tools/src/rct_image_tools/image_observation_finder.cpp
+++ b/rct_image_tools/src/rct_image_tools/image_observation_finder.cpp
@@ -30,18 +30,21 @@ static cv::Mat renderObservations(const cv::Mat& input, const ObservationPoints&
   cv::Mat output_image;
   input.copyTo(output_image);
 
-  cv::Size pattern_size(target.cols, target.rows);
+  if (!observation_points.empty())
+  {
+    cv::Size pattern_size(target.cols, target.rows);
 
-  cv::Mat center_image = cv::Mat(observation_points);
-  cv::Mat center_converted;
-  center_image.convertTo(center_converted, CV_32F);
-  cv::drawChessboardCorners(output_image, pattern_size, center_converted, true);
+    cv::Mat center_image = cv::Mat(observation_points);
+    cv::Mat center_converted;
+    center_image.convertTo(center_converted, CV_32F);
+    cv::drawChessboardCorners(output_image, pattern_size, center_converted, true);
 
-  // Draw point labels // TODO
-  drawPointLabel("First Point", observation_points[0], CvScalar(0, 255, 0), output_image);
-  drawPointLabel("Origin", observation_points[target.rows * target.cols - target.cols], CvScalar(255, 0, 0),
-                 output_image);
-  drawPointLabel("Last Point", observation_points[observation_points.size() - 1], CvScalar(0, 0, 255), output_image);
+    // Draw point labels // TODO
+    drawPointLabel("First Point", observation_points[0], CvScalar(0, 255, 0), output_image);
+    drawPointLabel("Origin", observation_points[target.rows * target.cols - target.cols], CvScalar(255, 0, 0),
+                   output_image);
+    drawPointLabel("Last Point", observation_points[observation_points.size() - 1], CvScalar(0, 0, 255), output_image);
+  }
 
   return output_image;
 }

--- a/rct_optimizations/CMakeLists.txt
+++ b/rct_optimizations/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(${PROJECT_NAME}
   # Optimizations (multiple cameras)
   src/${PROJECT_NAME}/extrinsic_multi_static_camera.cpp
   src/${PROJECT_NAME}/extrinsic_multi_static_camera_only.cpp
+  src/${PROJECT_NAME}/extrinsic_multi_static_camera_wrist_only.cpp
   # Optimizations (3D sensor)
   src/${PROJECT_NAME}/extrinsic_3d_camera_on_wrist.cpp
   # Optimizations (Experimental) - Intrinsic

--- a/rct_optimizations/CMakeLists.txt
+++ b/rct_optimizations/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(${PROJECT_NAME}
   src/${PROJECT_NAME}/extrinsic_static_camera.cpp
   # Optimizations (multiple cameras)
   src/${PROJECT_NAME}/extrinsic_multi_static_camera.cpp
+  src/${PROJECT_NAME}/extrinsic_multi_static_camera_only.cpp
   # Optimizations (3D sensor)
   src/${PROJECT_NAME}/extrinsic_3d_camera_on_wrist.cpp
   # Optimizations (Experimental) - Intrinsic

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_only.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_only.h
@@ -12,8 +12,8 @@
  * author: Levi Armstrong
  */
 
-#ifndef RCT_EXTRINSIC_MULTI_STATIC_CAMERA_H
-#define RCT_EXTRINSIC_MULTI_STATIC_CAMERA_H
+#ifndef RCT_EXTRINSIC_MULTI_STATIC_CAMERA_ONLY_H
+#define RCT_EXTRINSIC_MULTI_STATIC_CAMERA_ONLY_H
 
 #include "rct_optimizations/types.h"
 #include <Eigen/Dense>
@@ -22,33 +22,35 @@
 namespace rct_optimizations
 {
 
-struct ExtrinsicMultiStaticCameraMovingTargetProblem
+struct ExtrinsicMultiStaticCameraOnlyProblem
 {
+  /** @brief This is usefull in camera to camera calibration like stereo calibration and
+   * the transform between cameras is needed
+   */
+  bool fix_first_camera;
+
   /** @brief The basic camera intrinsic propeties: fx, fy, cx, cy used to reproject points;
       one for each camera */
   std::vector<CameraIntrinsics> intr;
 
-  /** @brief The transforms, "base to wrist", at which each observation set was taken. The outer
-   * vector is for each camera, the inner vector is the poses valid for that camera. This inner
-   * vector should match the inner vector of @e image_observations in size.
+  /** @brief The transforms, "base to target", at which each observation set was taken.
+   * The vector is the poses valid for each camera. This vector should match the inner
+   * vector of @e image_observations in size.
    */
-  std::vector<std::vector<Eigen::Affine3d>> wrist_poses;
+  std::vector<Eigen::Affine3d> base_to_target_guess;
 
-  /** @brief A sequence of observation sets corresponding to the image locations in @e wrist_poses.
+  /** @brief A sequence of observation sets corresponding to the image locations in @e base_to_target_guess.
    * Each observation set consists of a set of correspodences: a 3D position (e.g. a dot) in "target
    * frame" to the image location it was detected at (2D). The outer-most vector is for each camera,
    * the inner vector is the images valid for that camera.
    */
   std::vector<std::vector<CorrespondenceSet>> image_observations;
 
-  /** @brief Your best guess at the "wrist frame" to "target frame" transform */
-  Eigen::Affine3d wrist_to_target_guess;
-
   /** @brief Your best guess at the "base frame" to "camera frame" transform; one for each camera */
   std::vector<Eigen::Affine3d> base_to_camera_guess;
 };
 
-struct ExtrinsicMultiStaticCameraMovingTargetResult
+struct ExtrinsicMultiStaticCameraOnlyResult
 {
   /**
    * @brief Whether the underlying solver converged. If this is false, your calibration did not go well.
@@ -71,19 +73,15 @@ struct ExtrinsicMultiStaticCameraMovingTargetResult
    */
   double final_cost_per_obs;
 
-  /**
-   * @brief The final calibrated result of "wrist frame" to "target frame".
-   */
-  Eigen::Affine3d wrist_to_target;
+  /** @brief The final calibrated result of "base frame" to "target frame". */
+  std::vector<Eigen::Affine3d> base_to_target;
 
-  /**
-   * @brief The final calibrated result of "base frame" to "camera optical frame".
-   */
+  /** @brief The final calibrated result of "base frame" to "camera optical frame". */
   std::vector<Eigen::Affine3d> base_to_camera;
 };
 
-ExtrinsicMultiStaticCameraMovingTargetResult optimize(const ExtrinsicMultiStaticCameraMovingTargetProblem& params);
+ExtrinsicMultiStaticCameraOnlyResult optimize(const ExtrinsicMultiStaticCameraOnlyProblem& params);
 
 }
 
-#endif // RCT_EXTRINSIC_MULTI_STATIC_CAMERA_H
+#endif // RCT_EXTRINSIC_MULTI_STATIC_CAMERA_ONLY_H

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_wrist_only.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_wrist_only.h
@@ -1,0 +1,92 @@
+/*
+ * This file mirrors the interface for ExtrinsicStaticCameraMovingTarget found in
+ * rct_optimizations/extrinsic_static_camera.h but extends it to work for simultaneously
+ * localizing multiple cameras.
+ *
+ * Thus you now pass:
+ *  1. A vector of intrinsics, one for each camera
+ *  2. A vector of vector of wrist poses, one for each camera
+ *  2. A vector of vector of image observations, one for each camera
+ *  3. A vector of base to camera guesses, one for each camera
+ *
+ * author: Levi Armstrong
+ */
+
+#ifndef RCT_EXTRINSIC_MULTI_STATIC_CAMERA_WRIST_ONLY_H
+#define RCT_EXTRINSIC_MULTI_STATIC_CAMERA_WRIST_ONLY_H
+
+#include "rct_optimizations/types.h"
+#include <Eigen/Dense>
+#include <vector>
+
+namespace rct_optimizations
+{
+
+struct ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem
+{
+  /** @brief The basic camera intrinsic propeties: fx, fy, cx, cy used to reproject points;
+      one for each camera */
+  std::vector<CameraIntrinsics> intr;
+
+  /** @brief The transforms, "base to wrist", at which each observation set was taken.
+   * The vector is the poses valid for each camera. This vector should match the inner
+   * vector of @e image_observations in size.
+   */
+  std::vector<Eigen::Affine3d> wrist_poses;
+
+  /** @brief A sequence of observation sets corresponding to the image locations in @e wrist_poses.
+   * Each observation set consists of a set of correspodences: a 3D position (e.g. a dot) in "target
+   * frame" to the image location it was detected at (2D). The outer-most vector is for each camera,
+   * the inner vector is the images valid for that camera.
+   */
+  std::vector<std::vector<CorrespondenceSet>> image_observations;
+
+  /** @brief Your best guess at the "wrist frame" to "target frame" transform */
+  Eigen::Affine3d wrist_to_target_guess;
+
+  /** @brief Your best guess at the "base frame" to "camera frame" transform; one for each camera.
+   * Also it assumses the relationship between the cameras is correct and fixed, so it will
+   * calibrating the set of cameras using a single transformation.
+    */
+  std::vector<Eigen::Affine3d> base_to_camera_guess;
+};
+
+struct ExtrinsicMultiStaticCameraMovingTargetWristOnlyResult
+{
+  /**
+   * @brief Whether the underlying solver converged. If this is false, your calibration did not go well.
+   * If this is true, your calibration MAY have gone well.
+   */
+  bool converged;
+
+  /**
+   * @brief The initial reprojection error (in pixels) per residual based on your input guesses.
+   */
+  double initial_cost_per_obs;
+
+  /**
+   * @brief The final reprojection error (in pixels) per residual after optimization. Note that each circle
+   * has two residuals: a U and V error in the image. So a value of 1.2 means that each circle was described
+   * to within 1.2 pixels in X and 1.2 pixels in Y.
+   *
+   * A low value here is encouraging if you had a diversity of images. If you took few images, you can get
+   * a low score without getting a calibration that describes your workcell.
+   */
+  double final_cost_per_obs;
+
+  /**
+   * @brief The final calibrated result of "wrist frame" to "target frame".
+   */
+  Eigen::Affine3d wrist_to_target;
+
+  /**
+   * @brief The final calibrated result of "base frame" to "camera optical frame".
+   */
+  std::vector<Eigen::Affine3d> base_to_camera;
+};
+
+ExtrinsicMultiStaticCameraMovingTargetWristOnlyResult optimize(const ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem& params);
+
+}
+
+#endif // RCT_EXTRINSIC_MULTI_STATIC_CAMERA_WRIST_ONLY_H

--- a/rct_optimizations/src/rct_optimizations/extrinsic_multi_static_camera_only.cpp
+++ b/rct_optimizations/src/rct_optimizations/extrinsic_multi_static_camera_only.cpp
@@ -150,9 +150,6 @@ rct_optimizations::optimize(const rct_optimizations::ExtrinsicMultiStaticCameraO
   ceres::Solver::Options options;
   ceres::Solver::Summary summary;
 
-//  options.initial_trust_region_radius = 0.25;
-//  options.max_trust_region_radius = 1;
-
   ceres::Solve(options, &problem, &summary);
 
   ExtrinsicMultiStaticCameraOnlyResult result;

--- a/rct_optimizations/src/rct_optimizations/extrinsic_multi_static_camera_only.cpp
+++ b/rct_optimizations/src/rct_optimizations/extrinsic_multi_static_camera_only.cpp
@@ -1,0 +1,172 @@
+#include "rct_optimizations/extrinsic_multi_static_camera_only.h"
+#include "rct_optimizations/ceres_math_utilities.h"
+#include "rct_optimizations/eigen_conversions.h"
+#include "rct_optimizations/types.h"
+
+#include <ceres/ceres.h>
+#include <iostream>
+
+using namespace rct_optimizations;
+
+namespace
+{
+
+class ReprojectionFreeCameraCost
+{
+public:
+  ReprojectionFreeCameraCost(const Eigen::Vector2d& obs, const CameraIntrinsics& intr, const Eigen::Vector3d& point_in_target)
+    : obs_(obs), intr_(intr), target_pt_(point_in_target)
+  {}
+
+  template <typename T>
+  bool operator() (const T* const pose_camera_to_base, const T* pose_base_to_target, T* residual) const
+  {
+    const T* camera_angle_axis = pose_camera_to_base + 0;
+    const T* camera_position = pose_camera_to_base + 3;
+
+    const T* target_angle_axis = pose_base_to_target + 0;
+    const T* target_position = pose_base_to_target + 3;
+
+    T world_point[3]; // Point in world coordinates (base of robot)
+    T camera_point[3]; // Point in camera coordinates
+
+    // Transform points into camera coordinates
+    T target_pt[3];
+    target_pt[0] = T(target_pt_(0));
+    target_pt[1] = T(target_pt_(1));
+    target_pt[2] = T(target_pt_(2));
+
+    transformPoint(target_angle_axis, target_position, target_pt, world_point);
+    transformPoint(camera_angle_axis, camera_position, world_point, camera_point);
+
+    // Compute projected point into image plane and compute residual
+    T xy_image[2];
+    projectPoint(intr_, camera_point, xy_image);
+
+    residual[0] = xy_image[0] - obs_.x();
+    residual[1] = xy_image[1] - obs_.y();
+
+    return true;
+  }
+
+private:
+  Eigen::Vector2d obs_;
+  CameraIntrinsics intr_;
+  Eigen::Vector3d target_pt_;
+};
+
+class ReprojectionFixedCameraCost
+{
+public:
+  ReprojectionFixedCameraCost(const Eigen::Vector2d& obs, const CameraIntrinsics& intr, const Eigen::Affine3d& base_to_camera, const Eigen::Vector3d& point_in_target)
+    : obs_(obs), intr_(intr), camera_to_base_(poseEigenToCal(base_to_camera.inverse())), target_pt_(point_in_target)
+  {}
+
+  template <typename T>
+  bool operator() (const T* const pose_base_to_target, T* residual) const
+  {
+    const T* target_angle_axis = pose_base_to_target + 0;
+    const T* target_position = pose_base_to_target + 3;
+
+    T world_point[3]; // Point in world coordinates (base of robot)
+    T camera_point[3]; // Point in camera coordinates
+
+    // Transform points into camera coordinates
+    T target_pt[3];
+    target_pt[0] = T(target_pt_(0));
+    target_pt[1] = T(target_pt_(1));
+    target_pt[2] = T(target_pt_(2));
+
+    transformPoint(target_angle_axis, target_position, target_pt, world_point);
+    poseTransformPoint(camera_to_base_, world_point, camera_point);
+
+    // Compute projected point into image plane and compute residual
+    T xy_image[2];
+    projectPoint(intr_, camera_point, xy_image);
+
+    residual[0] = xy_image[0] - obs_.x();
+    residual[1] = xy_image[1] - obs_.y();
+
+    return true;
+  }
+
+private:
+  Eigen::Vector2d obs_;
+  CameraIntrinsics intr_;
+  Pose6d camera_to_base_;
+  Eigen::Vector3d target_pt_;
+};
+
+}
+
+rct_optimizations::ExtrinsicMultiStaticCameraOnlyResult
+rct_optimizations::optimize(const rct_optimizations::ExtrinsicMultiStaticCameraOnlyProblem& params)
+{
+  std::vector<Pose6d> internal_base_to_target;
+  std::vector<Pose6d> internal_camera_to_base;
+  internal_camera_to_base.resize(params.base_to_camera_guess.size());
+  internal_base_to_target.resize(params.base_to_target_guess.size());
+
+  ceres::Problem problem;
+
+  for (std::size_t i = 0; i < params.base_to_target_guess.size(); ++i) // For each wrist pose / image set
+  {
+    internal_base_to_target[i] = poseEigenToCal(params.base_to_target_guess[i]);
+    for (std::size_t c = 0; c < params.base_to_camera_guess.size(); ++c) // For each camera
+    {
+      assert(params.image_observations[c].size() == params.base_to_target_guess.size());
+      internal_camera_to_base[c] = poseEigenToCal(params.base_to_camera_guess[c].inverse());
+
+      for (std::size_t j = 0; j < params.image_observations[c][i].size(); ++j) // For each 3D point seen in the 2D image
+      {
+        // Define
+        const auto& img_obs = params.image_observations[c][i][j].in_image;
+        const auto& point_in_target = params.image_observations[c][i][j].in_target;
+        const auto& intr = params.intr[c];
+
+        // Allocate Ceres data structures - ownership is taken by the ceres
+        // Problem data structure
+        if (params.fix_first_camera && (c == 0))
+        {
+          auto* cost_fn = new ReprojectionFixedCameraCost(img_obs, intr, params.base_to_camera_guess[c], point_in_target);
+
+          auto* cost_block = new ceres::AutoDiffCostFunction<ReprojectionFixedCameraCost, 2, 6>(cost_fn);
+
+          problem.AddResidualBlock(cost_block, NULL, internal_base_to_target[i].values.data());
+        }
+        else
+        {
+          auto* cost_fn = new ReprojectionFreeCameraCost(img_obs, intr, point_in_target);
+
+          auto* cost_block = new ceres::AutoDiffCostFunction<ReprojectionFreeCameraCost, 2, 6, 6>(cost_fn);
+
+          problem.AddResidualBlock(cost_block, NULL, internal_camera_to_base[c].values.data(),
+                                   internal_base_to_target[i].values.data());
+        }
+      }
+    } // for each wrist pose
+  } // end for each camera
+
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+
+//  options.initial_trust_region_radius = 0.25;
+//  options.max_trust_region_radius = 1;
+
+  ceres::Solve(options, &problem, &summary);
+
+  ExtrinsicMultiStaticCameraOnlyResult result;
+  result.base_to_camera.resize(params.base_to_camera_guess.size());
+  result.base_to_target.resize(params.base_to_target_guess.size());
+  result.converged = summary.termination_type == ceres::CONVERGENCE;
+
+  for (std::size_t i = 0; i < params.base_to_camera_guess.size(); ++i)
+    result.base_to_camera[i] = poseCalToEigen(internal_camera_to_base[i]).inverse();
+
+  for (std::size_t i = 0; i < params.base_to_target_guess.size(); ++i)
+    result.base_to_target[i] = poseCalToEigen(internal_base_to_target[i]);
+
+  result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
+  result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
+  return result;
+}

--- a/rct_optimizations/src/rct_optimizations/extrinsic_multi_static_camera_wrist_only.cpp
+++ b/rct_optimizations/src/rct_optimizations/extrinsic_multi_static_camera_wrist_only.cpp
@@ -1,0 +1,120 @@
+#include "rct_optimizations/extrinsic_multi_static_camera_wrist_only.h"
+#include "rct_optimizations/ceres_math_utilities.h"
+#include "rct_optimizations/eigen_conversions.h"
+#include "rct_optimizations/types.h"
+
+#include <ceres/ceres.h>
+#include <iostream>
+
+using namespace rct_optimizations;
+
+namespace
+{
+
+class ReprojectionCost
+{
+public:
+  ReprojectionCost(const Eigen::Vector2d& obs, const CameraIntrinsics& intr, const Eigen::Affine3d& base_to_wrist,
+                   const Eigen::Affine3d& base_to_camera, const Eigen::Vector3d& point_in_target)
+    : obs_(obs), intr_(intr), wrist_pose_(poseEigenToCal(base_to_wrist)), camera_to_base_orig_(poseEigenToCal(base_to_camera.inverse())), target_pt_(point_in_target)
+  {}
+
+  template <typename T>
+  bool operator() (const T* const pose_camera_to_base_correction, const T* pose_wrist_to_target, T* residual) const
+  {
+    const T* camera_angle_axis = pose_camera_to_base_correction + 0;
+    const T* camera_position = pose_camera_to_base_correction + 3;
+
+    const T* target_angle_axis = pose_wrist_to_target + 0;
+    const T* target_position = pose_wrist_to_target + 3;
+
+    T link_point[3]; // Point in wrist coordinates
+    T world_point[3]; // Point in world coordinates (base of robot)
+    T camera_point_orig[3]; // Point in camera coordinates before correction
+    T camera_point[3]; // Point in camera coordinates
+
+
+    // Transform points into camera coordinates
+    T target_pt[3];
+    target_pt[0] = T(target_pt_(0));
+    target_pt[1] = T(target_pt_(1));
+    target_pt[2] = T(target_pt_(2));
+
+    transformPoint(target_angle_axis, target_position, target_pt, link_point);
+    poseTransformPoint(wrist_pose_, link_point, world_point);
+    transformPoint(camera_angle_axis, camera_position, world_point, camera_point_orig);
+    poseTransformPoint(camera_to_base_orig_, camera_point_orig, camera_point);
+
+    // Compute projected point into image plane and compute residual
+    T xy_image[2];
+    projectPoint(intr_, camera_point, xy_image);
+
+    residual[0] = xy_image[0] - obs_.x();
+    residual[1] = xy_image[1] - obs_.y();
+
+    return true;
+  }
+
+private:
+  Eigen::Vector2d obs_;
+  CameraIntrinsics intr_;
+  Pose6d wrist_pose_;
+  Pose6d camera_to_base_orig_;
+  Eigen::Vector3d target_pt_;
+};
+
+}
+
+rct_optimizations::ExtrinsicMultiStaticCameraMovingTargetWristOnlyResult
+rct_optimizations::optimize(const rct_optimizations::ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem& params)
+{
+  Pose6d internal_wrist_to_target = poseEigenToCal(params.wrist_to_target_guess);
+
+  Pose6d internal_camera_to_base_correction = poseEigenToCal(Eigen::Affine3d::Identity());
+
+  ceres::Problem problem;
+
+  for (std::size_t c = 0; c < params.base_to_camera_guess.size(); ++c) // For each camera
+  {
+    assert(params.image_observations[c].size() == params.wrist_poses.size());
+    for (std::size_t i = 0; i < params.wrist_poses.size(); ++i) // For each wrist pose / image set
+    {
+      for (std::size_t j = 0; j < params.image_observations[c][i].size(); ++j) // For each 3D point seen in the 2D image
+      {
+        // Define
+        const auto& img_obs = params.image_observations[c][i][j].in_image;
+        const auto& point_in_target = params.image_observations[c][i][j].in_target;
+        const auto& base_to_wrist = params.wrist_poses[i];
+        const auto& base_to_camera_orig = params.base_to_camera_guess[c];
+        const auto& intr = params.intr[c];
+
+        // Allocate Ceres data structures - ownership is taken by the ceres
+        // Problem data structure
+        auto* cost_fn = new ReprojectionCost(img_obs, intr, base_to_wrist, base_to_camera_orig, point_in_target);
+
+        auto* cost_block = new ceres::AutoDiffCostFunction<ReprojectionCost, 2, 6, 6>(cost_fn);
+
+        problem.AddResidualBlock(cost_block, NULL, internal_camera_to_base_correction.values.data(),
+                                 internal_wrist_to_target.values.data());
+      }
+    } // for each wrist pose
+  } // end for each camera
+
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+
+  ceres::Solve(options, &problem, &summary);
+
+  ExtrinsicMultiStaticCameraMovingTargetWristOnlyResult result;
+  result.base_to_camera.resize(params.base_to_camera_guess.size());
+  result.converged = summary.termination_type == ceres::CONVERGENCE;
+
+  Eigen::Affine3d base_to_camera_correction = poseCalToEigen(internal_camera_to_base_correction).inverse();
+  for (std::size_t i = 0; i < params.base_to_camera_guess.size(); ++i)
+    result.base_to_camera[i] = base_to_camera_correction * params.base_to_camera_guess[i];
+
+  result.wrist_to_target = poseCalToEigen(internal_wrist_to_target);
+  result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
+  result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
+  return result;
+}

--- a/rct_ros_tools/include/rct_ros_tools/data_set.h
+++ b/rct_ros_tools/include/rct_ros_tools/data_set.h
@@ -4,6 +4,8 @@
 #include <boost/optional.hpp>
 #include <Eigen/Dense>
 #include <opencv2/core.hpp>
+#include <rct_optimizations/types.h>
+#include <rct_image_tools/image_observation_finder.h>
 
 namespace rct_ros_tools
 {
@@ -17,6 +19,44 @@ struct ExtrinsicDataSet
 boost::optional<ExtrinsicDataSet> parseFromFile(const std::string& path);
 
 bool saveToDirectory(const std::string& path, const ExtrinsicDataSet& data);
+
+/**
+ * @brief This class is used to generate correspondence sets for one/multiple static cameras
+ * and a single moveing target.
+ */
+class ExtrinsicCorrespondenceDataSet
+{
+public:
+  ExtrinsicCorrespondenceDataSet(const std::vector<rct_ros_tools::ExtrinsicDataSet> &extrinsic_data_set,
+                                 const rct_image_tools::ModifiedCircleGridObservationFinder &obs_finder,
+                                 bool debug = false);
+
+  /** @brief Get the number of cameras */
+  std::size_t getCameraCount() const;
+
+  /** @brief Get the number of images taken by each camera */
+  std::size_t getImageCount() const;
+
+  /** @brief Get numbers of cameras that found a image */
+  std::size_t getImageCameraCount(std::size_t image_index) const;
+
+  /** @brief Get number of images found by a camera */
+  std::size_t getCameraImageCount(std::size_t camera_index) const;
+
+  /** @brief Get if a correspondence set was found camera image pair */
+  bool foundCorrespondence(std::size_t camera_index, std::size_t image_index) const;
+
+  /** @brief Get the correspondence set for a given camera and image index */
+  const rct_optimizations::CorrespondenceSet& getCorrespondenceSet(std::size_t camera_index, std::size_t image_index) const;
+
+private:
+  /** @brief Correspondence pairs for a given image and camera */
+  Eigen::Matrix<rct_optimizations::CorrespondenceSet, Eigen::Dynamic, Eigen::Dynamic> correspondences_;
+
+  /** @brief Mask matrix indicating if the target was found */
+  Eigen::Matrix<unsigned, Eigen::Dynamic, Eigen::Dynamic> mask_;
+
+};
 
 }
 

--- a/rct_ros_tools/include/rct_ros_tools/print_utils.h
+++ b/rct_ros_tools/include/rct_ros_tools/print_utils.h
@@ -1,0 +1,144 @@
+#ifndef RCT_PRINT_UTILS_H
+#define RCT_PRINT_UTILS_H
+#include <Eigen/Dense>
+#include <iostream>
+
+namespace rct_ros_tools
+{
+
+inline
+std::string getStringRPY(const Eigen::Vector3d& rpy)
+{
+  std::stringstream s;
+  s << "rpy=\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"";
+  return s.str();
+}
+
+inline
+std::string getStringXYZ(const Eigen::Vector3d& xyz)
+{
+  std::stringstream s;
+  s << "xyz=\"" << xyz(0) << " " << xyz(1) << " " << xyz(2) << "\"";
+  return s.str();
+}
+
+inline
+std::string getStringQuaternion(const Eigen::Quaterniond& q)
+{
+  std::stringstream s;
+  s << "qxyzw=\"" << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << "\"";
+  return s.str();
+}
+
+inline
+std::string getStringIntrinsics(const std::array<double, 4> &values)
+{
+  std::stringstream s;
+  s << "New Intr:\nfx = " << values[0]
+    << "\tfy = " << values[1]
+    << "\ncx = " << values[2]
+    << "\tcy = " << values[3];
+  return s.str();
+}
+
+inline
+std::string getStringDistortion(const std::array<double, 5> &values)
+{
+  std::stringstream s;
+  s << "Distortions:\n"
+    << "k1 = " << values[0]
+    << "\tk2 = " << values[1]
+    << "\tp1 = " << values[2]
+    << "\tp2 = " << values[3]
+    << "\tk3 = " << values[4];
+  return s.str();
+}
+
+inline
+void printNewLine()
+{
+  std::cout << std::endl;
+}
+
+inline
+void printTitle(const std::string& title, int width = 80)
+{
+  int length = title.length() + 8;
+  if (length < width)
+    length = width;
+
+  std::string full;
+  std::string mid;
+  int delta = (length - title.length()) / 2;
+  if ((int)(delta + delta + title.length()) == length)
+  {
+    full = std::string(length, '*');
+    mid = std::string(delta - 1, '*');
+  }
+  else
+  {
+    full = std::string(length + 1, '*');
+    mid = std::string(delta, '*');
+  }
+  std::cout << full << std::endl;
+  std::cout << mid << " " << title << " " << mid << std::endl;
+  std::cout << full << std::endl;
+}
+
+inline
+void printTransform(const Eigen::Affine3d &transform, const std::string &parent_frame, const std::string &child_frame, const std::string &description)
+{
+  std::cout << description << ":" << std::endl << transform.matrix() << std::endl << std::endl;
+  std::cout << "--- URDF Format " << parent_frame << " to " << child_frame << " ---" << std::endl;
+  Eigen::Vector3d rpy = transform.rotation().eulerAngles(2, 1, 0);
+  Eigen::Quaterniond q(transform.rotation());
+  std::cout << getStringXYZ(transform.translation()) << std::endl;
+  std::cout << getStringRPY(rpy) << std::endl;
+  std::cout << getStringQuaternion(q) << std::endl;
+}
+
+inline
+void printTransformDiff(const Eigen::Affine3d &transform1, const Eigen::Affine3d &transform2, const std::string &parent_frame, const std::string &child_frame, const std::string &description)
+{
+  Eigen::Affine3d delta = transform1.inverse() * transform2;
+  Eigen::AngleAxisd aa (delta.linear());
+  Eigen::Vector3d rpy = delta.rotation().eulerAngles(2, 1, 0);
+
+  std::cout << description << ":" << std::endl;
+  std::cout << "--- " << parent_frame << " to " << child_frame << " Diff ---" << std::endl;
+
+  Eigen::Vector3d trans = transform2.translation() - transform1.translation();
+  std::cout << "DELTA S: " << trans.norm() << " at " << getStringXYZ(trans) << std::endl;
+  std::cout << "DELTA A: " << (180.0 * aa.angle() / M_PI) << " and " << getStringRPY(rpy) << std::endl << std::endl;
+
+  std::cout << "--- " << parent_frame << " to " << child_frame << " Diff Relative To Transform 1 ---" << std::endl;
+  std::cout << delta.matrix() << std::endl << std::endl;
+
+  std::cout << "DELTA S: " << delta.translation().norm() << " at " << getStringXYZ(delta.translation()) << std::endl;
+  std::cout << "DELTA A: " << (180.0 * aa.angle() / M_PI) << " and " << getStringRPY(rpy) << std::endl;
+}
+
+inline
+void printOptResults(bool converged, double initial_cost_per_obs, double final_cost_per_obs)
+{
+  std::cout << "Did converge?: " << converged << std::endl;
+  std::cout << "Initial cost?: " << initial_cost_per_obs << " (pixels per dot)" << std::endl;
+  std::cout << "Final cost?: " << final_cost_per_obs << " (pixels per dot)" << std::endl;
+}
+
+inline
+void printCameraIntrinsics(const std::array<double, 4> &values, const std::string &description)
+{
+  std::cout << description << ":" << std::endl;
+  std::cout << getStringIntrinsics(values) << std::endl;
+}
+
+inline
+void printCameraDistortion(const std::array<double, 5> &values, const std::string &description)
+{
+  std::cout << description << ":" << std::endl;
+  std::cout << getStringDistortion(values) << std::endl;
+}
+
+}
+#endif // RCT_PRINT_UTILS_H

--- a/rct_ros_tools/src/data_loader/data_set.cpp
+++ b/rct_ros_tools/src/data_loader/data_set.cpp
@@ -23,7 +23,12 @@ static std::string combine(const std::string& dir, const std::string& rel_path)
 
 static cv::Mat readImageOpenCV(const std::string& path)
 {
-  return cv::imread(path, CV_LOAD_IMAGE_COLOR); // TODO: Is CV_LOAD_IMAGE_COLOR needed?
+  cv::Mat image = cv::imread(path, CV_LOAD_IMAGE_COLOR); // TODO: Is CV_LOAD_IMAGE_COLOR needed?
+  if (image.data == NULL)
+  {
+    ROS_ERROR("File failed to load or does not exist: %s", path.c_str());
+  }
+  return image;
 }
 
 static rct_ros_tools::ExtrinsicDataSet parse(const YAML::Node& root, const std::string& root_path)

--- a/rct_ros_tools/src/data_loader/data_set.cpp
+++ b/rct_ros_tools/src/data_loader/data_set.cpp
@@ -1,5 +1,6 @@
 #include "rct_ros_tools/data_set.h"
 #include "rct_ros_tools/parameter_loaders.h"
+#include "rct_image_tools/image_utils.h"
 
 #include <yaml-cpp/yaml.h>
 #include <ros/console.h>
@@ -122,4 +123,76 @@ bool rct_ros_tools::saveToDirectory(const std::string& path, const rct_ros_tools
   writeDirectory(path + "/data.yaml", data);
 
   return true;
+}
+
+rct_ros_tools::ExtrinsicCorrespondenceDataSet::ExtrinsicCorrespondenceDataSet(const std::vector<rct_ros_tools::ExtrinsicDataSet> &extrinsic_data_set,
+                                                                              const rct_image_tools::ModifiedCircleGridObservationFinder &obs_finder,
+                                                                              bool debug)
+{
+  correspondences_.resize(extrinsic_data_set.size(), extrinsic_data_set[0].images.size());
+  mask_.resize(extrinsic_data_set.size(), extrinsic_data_set[0].images.size());
+  for (std::size_t c = 0; c < extrinsic_data_set.size(); ++c)
+  {
+    // We know it exists, so define a helpful alias
+    const rct_ros_tools::ExtrinsicDataSet& data_set = extrinsic_data_set[c];
+
+    // Finally, we need to process our images into correspondence sets: for each dot in the
+    // target this will be where that dot is in the target and where it was seen in the image.
+    // Repeat for each image. We also tell where the wrist was when the image was taken.
+    for (std::size_t i = 0; i < data_set.images.size(); ++i)
+    {
+      mask_(c, i) = 1;
+      // Try to find the circle grid in this image:
+      rct_optimizations::CorrespondenceSet obs_set = rct_image_tools::getCorrespondenceSet(obs_finder, data_set.images[i]);
+      if (obs_set.empty())
+      {
+        ROS_WARN_STREAM("Unable to find the circle grid in image: " << i);
+        mask_(c, i) = 0;
+      }
+
+      if (debug)
+      {
+        // Show the points we detected
+        std::vector<Eigen::Vector2d> observations(obs_set.size());
+        std::transform(obs_set.begin(), obs_set.end(), observations.begin(),
+                       [](const rct_optimizations::Correspondence2D3D& o) { return o.in_image; });
+
+        cv::imshow("points", obs_finder.drawObservations(data_set.images[i], observations));
+        cv::waitKey();
+      }
+
+      correspondences_(c, i) = obs_set;
+    }
+  }
+}
+
+std::size_t rct_ros_tools::ExtrinsicCorrespondenceDataSet::getCameraCount() const
+{
+  return correspondences_.rows();
+}
+
+std::size_t rct_ros_tools::ExtrinsicCorrespondenceDataSet::getImageCount() const
+{
+  return correspondences_.cols();
+}
+
+std::size_t rct_ros_tools::ExtrinsicCorrespondenceDataSet::getImageCameraCount(std::size_t image_index) const
+{
+  return mask_.col(image_index).sum();
+}
+
+std::size_t rct_ros_tools::ExtrinsicCorrespondenceDataSet::getCameraImageCount(std::size_t camera_index) const
+{
+  return mask_.row(camera_index).sum();
+}
+
+bool rct_ros_tools::ExtrinsicCorrespondenceDataSet::foundCorrespondence(std::size_t camera_index, std::size_t image_index) const
+{
+  return static_cast<bool>(mask_(camera_index, image_index));
+}
+
+const rct_optimizations::CorrespondenceSet&
+rct_ros_tools::ExtrinsicCorrespondenceDataSet::getCorrespondenceSet(std::size_t camera_index, std::size_t image_index) const
+{
+  return correspondences_(camera_index, image_index);
 }


### PR DESCRIPTION
Due to robots not being globally accurate this PR add two new calibration. The first just calibrations the relationship between cameras and assumes the target is visible by all cameras. The second assumes the relationship between cameras is fixed but can be transformed as a group along with wrist calibration to locate the set of cameras to the robot.

Also, this PR adds a tool that will perform the target on wrist and multiple static camera calibration in two steps to achieve a higher accuracy calibration.

@Jmeyer1292 The class names are not a full description of the calibration being performed so I will create an issue to further discuss this.