### PR TITLE
Special handling for mono16 images in command_line_cal.cpp

### DIFF
--- a/rct_ros_tools/src/command_line_cal.cpp
+++ b/rct_ros_tools/src/command_line_cal.cpp
@@ -70,7 +70,19 @@ public:
     cv_bridge::CvImagePtr cv_ptr;
     try
     {
-      cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+      if(msg->encoding == "mono16")
+      {
+        cv_bridge::CvImagePtr temp_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::MONO16);
+
+        cv::Mat img_conv;
+        cv::cvtColor(temp_ptr->image, img_conv, CV_GRAY2BGR);
+        img_conv.convertTo(img_conv, CV_8UC1);
+        cv_ptr = cv_bridge::CvImagePtr(new cv_bridge::CvImage(temp_ptr->header, sensor_msgs::image_encodings::BGR8, img_conv));
+      }
+      else
+      {
+        cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+      }
 
       auto obs = finder_.findObservations(cv_ptr->image);
       if (obs)


### PR DESCRIPTION
Some RGBD camera drivers (in my case, the Orbbec Astra's) publish IR images as `mono16`, whereas the nifty command line capture tool expects images to use `rgb8`. This means that the IR images end up as entirely black -- not especially useful. I wanted to use IR images in my calibration process so I added a special case to `command_line_cal.cpp` to massage the bytes into the right configuration.

There's probably a better/cleaner/more elegant way to do this but I just wanted to get this tweak out there since it helped me solve a problem. 