### PR TITLE
Observation Refactor

### DIFF
--- a/rct_optimizations/CMakeLists.txt
+++ b/rct_optimizations/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/extrinsic_multi_static_camera_wrist_only.cpp
   # Optimizations (3D sensor)
   src/${PROJECT_NAME}/extrinsic_3d_camera_on_wrist.cpp
+  src/${PROJECT_NAME}/extrinsic_hand_eye.cpp
   # Optimizations (Experimental) - Intrinsic
   src/${PROJECT_NAME}/camera_intrinsic.cpp
   src/${PROJECT_NAME}/pnp.cpp

--- a/rct_optimizations/include/rct_optimizations/extrinsic_hand_eye.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_hand_eye.h
@@ -26,15 +26,15 @@ struct ExtrinsicHandEyeProblem2D3D
 {
   typename Observation2D3D::Set observations;
   CameraIntrinsics intr;
-  Eigen::Isometry3d base_to_target_guess;
-  Eigen::Isometry3d wrist_to_camera_guess;
+  Eigen::Isometry3d target_mount_to_target_guess;
+  Eigen::Isometry3d camera_mount_to_camera_guess;
 };
 
 struct ExtrinsicHandEyeProblem3D3D
 {
   typename Observation3D3D::Set observations;
-  Eigen::Isometry3d base_to_target_guess;
-  Eigen::Isometry3d wrist_to_camera_guess;
+  Eigen::Isometry3d target_mount_to_target_guess;
+  Eigen::Isometry3d camera_mount_to_camera_guess;
 };
 
 struct ExtrinsicHandEyeResult
@@ -43,8 +43,8 @@ struct ExtrinsicHandEyeResult
   double initial_cost_per_obs;
   double final_cost_per_obs;
 
-  Eigen::Isometry3d base_to_target;
-  Eigen::Isometry3d wrist_to_camera;
+  Eigen::Isometry3d target_mount_to_target;
+  Eigen::Isometry3d camera_mount_to_camera;
 };
 
 ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D &params);

--- a/rct_optimizations/include/rct_optimizations/extrinsic_hand_eye.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_hand_eye.h
@@ -1,0 +1,53 @@
+/*
+ * This file defines a solver for calibrating the EXTRINSIC parameters of a 3D
+ * camera attached to the wrist of a moving robot. It works by imaging a static target
+ * from many robot wrist positions.
+ *
+ * The only difference between this the and 2D, pinhole variety is that the correspondences
+ * in the observation set are 3D to 3D instead of 2D to 3D. This is meant for 3D sensors where
+ * you don't know (or don't want to know) the intrinsics of the sensor or they aren't well
+ * described by the pinhole model.
+ *
+ * For example, this calibration has been used to detect 3D features in a "3D image" produced
+ * by the IFM O3D3xx cameras. Sometimes you may want to use this for Openni cameras where
+ * because of terrible drivers your calibration does not affect the depth data.
+ *
+ * See extrinsic_camera_on_wrist.h for a description of the other parameters.
+ */
+#pragma once
+
+#include "rct_optimizations/types.h"
+#include <Eigen/Dense>
+#include <vector>
+
+namespace rct_optimizations
+{
+struct ExtrinsicHandEyeProblem2D3D
+{
+  typename Observation2D3D::Set observations;
+  CameraIntrinsics intr;
+  Eigen::Isometry3d base_to_target_guess;
+  Eigen::Isometry3d wrist_to_camera_guess;
+};
+
+struct ExtrinsicHandEyeProblem3D3D
+{
+  typename Observation3D3D::Set observations;
+  Eigen::Isometry3d base_to_target_guess;
+  Eigen::Isometry3d wrist_to_camera_guess;
+};
+
+struct ExtrinsicHandEyeResult
+{
+  bool converged;
+  double initial_cost_per_obs;
+  double final_cost_per_obs;
+
+  Eigen::Isometry3d base_to_target;
+  Eigen::Isometry3d wrist_to_camera;
+};
+
+ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D &params);
+ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem3D3D &params);
+
+} // namespace rct_optimizations

--- a/rct_optimizations/include/rct_optimizations/types.h
+++ b/rct_optimizations/include/rct_optimizations/types.h
@@ -52,33 +52,33 @@ struct Pose6d
 /**
  * @brief A pair of corresponding features in a N-dimensional sensor "image" and 3D target
  */
-template<Eigen::Index OBS_DIMENSION>
+template<Eigen::Index IMAGE_DIM, Eigen::Index WORLD_DIM>
 struct Correspondence
 {
-  using Set = std::vector<Correspondence<OBS_DIMENSION>>;
+  using Set = std::vector<Correspondence<IMAGE_DIM, WORLD_DIM>>;
   Correspondence()
-    : in_target(Eigen::Vector3d::Zero())
-    , in_image(Eigen::Matrix<double, OBS_DIMENSION, 1>::Zero())
+    : in_image(Eigen::Matrix<double, IMAGE_DIM, 1>::Zero())
+    , in_target(Eigen::Matrix<double, WORLD_DIM, 1>::Zero())
   {
   }
 
-  Correspondence(const Eigen::Vector3d& in_target_,
-                 const Eigen::Matrix<double, OBS_DIMENSION, 1>& in_image_)
+  Correspondence(const Eigen::Matrix<double, IMAGE_DIM, 1>& in_image_,
+                 const Eigen::Matrix<double, WORLD_DIM, 1>& in_target_)
     : in_target(in_target_)
     , in_image(in_image_)
   {
   }
 
-  /** @brief XYZ location of the feature relative to the target origin (meters) */
-  Eigen::Vector3d in_target;
-
   /** @brief N-dimensional location of the feature relative to the sensor */
-  Eigen::Matrix<double, OBS_DIMENSION, 1> in_image;
+  Eigen::Matrix<double, IMAGE_DIM, 1> in_image;
+
+  /** @brief N-dimensional location of the feature relative to the target origin */
+  Eigen::Matrix<double, WORLD_DIM, 1> in_target;
 };
 /** @brief Typedef for correspondence between 2D feature in image coordinates and 3D feature in target coordinates */
-using Correspondence2D3D = Correspondence<2>;
+using Correspondence2D3D = Correspondence<2, 3>;
 /** @brief Typedef for correspondence between 3D feature in sensor coordinates and 3D feature in target coordinates */
-using Correspondence3D3D = Correspondence<3>;
+using Correspondence3D3D = Correspondence<3, 3>;
 
 // Deprecated typedefs
 using CorrespondenceSet = Correspondence2D3D::Set;
@@ -95,10 +95,10 @@ using Correspondence3DSet = Correspondence3D3D::Set;
  *
  * Keep in mind that the optimization itself determines the final calibrated transforms from these "mount" frames to the camera and target.
  */
-template<Eigen::Index OBS_DIMENSION>
+template<Eigen::Index IMAGE_DIM, Eigen::Index WORLD_DIM>
 struct Observation
 {
-  using Set = std::vector<Observation<OBS_DIMENSION>>;
+  using Set = std::vector<Observation<IMAGE_DIM, WORLD_DIM>>;
   Observation()
     : to_camera_mount(Eigen::Isometry3d::Identity())
     , to_target_mount(Eigen::Isometry3d::Identity())
@@ -113,16 +113,16 @@ struct Observation
   }
 
   /** @brief A set of feature correspondences between the sensor output and target */
-  typename Correspondence<OBS_DIMENSION>::Set correspondence_set;
+  typename Correspondence<IMAGE_DIM, WORLD_DIM>::Set correspondence_set;
   /** @brief The transform to the frame to which the camera is mounted. */
   Eigen::Isometry3d to_camera_mount;
   /** @brief The transform to the frame to which the target is mounted. */
   Eigen::Isometry3d to_target_mount;
 };
 /** @brief Typedef for observations of 2D image to 3D target correspondences */
-using Observation2D3D = Observation<2>;
+using Observation2D3D = Observation<2, 3>;
 /** @brief Typedef for observations of 3D sensor to 3D target correspondences */
-using Observation3D3D = Observation<3>;
+using Observation3D3D = Observation<3, 3>;
 
 } // namespace rct_optimizations
 

--- a/rct_optimizations/include/rct_optimizations/types.h
+++ b/rct_optimizations/include/rct_optimizations/types.h
@@ -89,6 +89,10 @@ using Correspondence3DSet = Correspondence3D3D::Set;
  * This consists of the feature correspondences as well as the transforms to the "mount" frames of the camera and target.
  * For a moving camera or target, the "mount" pose would likely be the transform from the robot base to the robot tool flange.
  * For a stationary camera or target, this "mount" pose would simply be identity.
+ *
+ * Note that @ref to_camera_mount and @ref to_target_mount do not necessarily need to be relative the the same coordinate system because
+ * certain calibration problems might optimize a 6D transform in between the root frame of @ref to_camera mount and the root frame of @ref to_target_mount
+ *
  * Keep in mind that the optimization itself determines the final calibrated transforms from these "mount" frames to the camera and target.
  */
 template<Eigen::Index OBS_DIMENSION>
@@ -96,24 +100,24 @@ struct Observation
 {
   using Set = std::vector<Observation<OBS_DIMENSION>>;
   Observation()
-    : base_to_camera_mount(Eigen::Isometry3d::Identity())
-    , base_to_target_mount(Eigen::Isometry3d::Identity())
+    : to_camera_mount(Eigen::Isometry3d::Identity())
+    , to_target_mount(Eigen::Isometry3d::Identity())
   {
   }
 
-  Observation(const Eigen::Isometry3d& base_to_camera_mount_,
-              const Eigen::Isometry3d& base_to_target_mount_)
-    : base_to_camera_mount(base_to_camera_mount_)
-    , base_to_target_mount(base_to_target_mount_)
+  Observation(const Eigen::Isometry3d& to_camera_mount_,
+              const Eigen::Isometry3d& to_target_mount_)
+    : to_camera_mount(to_camera_mount_)
+    , to_target_mount(to_target_mount_)
   {
   }
 
   /** @brief A set of feature correspondences between the sensor output and target */
   typename Correspondence<OBS_DIMENSION>::Set correspondence_set;
-  /** @brief The transform from a common root frame to the frame to which the camera is mounted. */
-  Eigen::Isometry3d base_to_camera_mount;
-  /** @brief The transform from a common root frame to the frame to which the target is mounted. */
-  Eigen::Isometry3d base_to_target_mount;
+  /** @brief The transform to the frame to which the camera is mounted. */
+  Eigen::Isometry3d to_camera_mount;
+  /** @brief The transform to the frame to which the target is mounted. */
+  Eigen::Isometry3d to_target_mount;
 };
 /** @brief Typedef for observations of 2D image to 3D target correspondences */
 using Observation2D3D = Observation<2>;

--- a/rct_optimizations/include/rct_optimizations/types.h
+++ b/rct_optimizations/include/rct_optimizations/types.h
@@ -81,8 +81,8 @@ using Correspondence2D3D = Correspondence<2, 3>;
 using Correspondence3D3D = Correspondence<3, 3>;
 
 // Deprecated typedefs
-using CorrespondenceSet = Correspondence2D3D::Set;
-using Correspondence3DSet = Correspondence3D3D::Set;
+using CorrespondenceSet [[deprecated]] = Correspondence2D3D::Set;
+using Correspondence3DSet [[deprecated]] = Correspondence3D3D::Set;
 
 /**
  * @brief A set of data representing a single observation of a calibration target.

--- a/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
+++ b/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
@@ -71,67 +71,6 @@ protected:
   Eigen::Vector3d target_pt_;
 };
 
-//template<>
-//class ObservationCost<2>
-//{
-//  ObservationCost(const Eigen::Vector3d &obs,
-//                  const Eigen::Isometry3d &camera_mount_to_base,
-//                  const Eigen::Isometry3d &base_to_target_mount,
-//                  const Eigen::Matrix<double, 2, 1> &point_in_target,
-//                  const CameraIntrinsics& intr)
-//    : obs_(obs)
-//    , camera_mount_to_base_(poseEigenToCal(camera_mount_to_base))
-//    , base_to_target_mount_(poseEigenToCal(base_to_target_mount))
-//    , target_pt_(point_in_target)
-//    , intr_(intr)
-//  {
-//  }
-
-//  template<typename T>
-//  bool operator()(const T *pose_camera_to_camera_mount,
-//                  const T *pose_target_mount_to_target,
-//                  T *residual) const
-//  {
-//    // Get the point in the frame of the camera
-//    T camera_point[3];
-//    getTargetPointInCamera(pose_camera_to_camera_mount, pose_target_mount_to_target, camera_point);
-
-//    // Project the point into the image
-//    T xy_image[2];
-//    projectPoint(intr_, camera_point, xy_image);
-
-//    // Calculate the residual error
-//    residual[0] = xy_image[0] - obs_.x();
-//    residual[1] = xy_image[1] - obs_.y();
-
-//    return true;
-//  }
-
-//  Eigen::Matrix<double, 2, 1> obs_;
-//  Pose6d camera_mount_to_base_;
-//  Pose6d base_to_target_mount_;
-//  Eigen::Vector3d target_pt_;
-//  CameraIntrinsics intr_;
-//};
-
-//template<>
-//template<typename T>
-//bool ObservationCost<3>::operator()(const T *pose_camera_to_camera_mount,
-//                                    const T *pose_target_mount_to_target,
-//                                    T *residual) const
-//{
-//  // Get the target point in the frame of the camera
-//  T camera_point[3];
-//  getTargetPointInCamera(pose_camera_to_camera_mount, pose_target_mount_to_target, camera_point);
-
-//  // Calculate the residual error
-//  residual[0] = camera_point[0] - obs_.x();
-//  residual[1] = camera_point[1] - obs_.y();
-//  residual[2] = camera_point[2] - obs_.z();
-
-//  return true;
-//}
-
 /**
  * @brief The ObservationCost2D3D class
  */

--- a/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
+++ b/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
@@ -159,8 +159,8 @@ namespace rct_optimizations
 {
 ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D& params)
 {
-  Pose6d internal_base_to_target = poseEigenToCal(params.base_to_target_guess);
-  Pose6d internal_camera_to_wrist = poseEigenToCal(params.wrist_to_camera_guess.inverse());
+  Pose6d internal_base_to_target = poseEigenToCal(params.target_mount_to_target_guess);
+  Pose6d internal_camera_to_wrist = poseEigenToCal(params.camera_mount_to_camera_guess.inverse());
 
   ceres::Problem problem;
 
@@ -205,8 +205,8 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D& params)
 
   ExtrinsicHandEyeResult result;
   result.converged = summary.termination_type == ceres::CONVERGENCE;
-  result.base_to_target = poseCalToEigen(internal_base_to_target);
-  result.wrist_to_camera = poseCalToEigen(internal_camera_to_wrist).inverse();
+  result.target_mount_to_target = poseCalToEigen(internal_base_to_target);
+  result.camera_mount_to_camera = poseCalToEigen(internal_camera_to_wrist).inverse();
   result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
   result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
 
@@ -216,8 +216,8 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D& params)
 
 ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem3D3D& params)
 {
-  Pose6d internal_base_to_target = poseEigenToCal(params.base_to_target_guess);
-  Pose6d internal_camera_to_wrist = poseEigenToCal(params.wrist_to_camera_guess.inverse());
+  Pose6d internal_base_to_target = poseEigenToCal(params.target_mount_to_target_guess);
+  Pose6d internal_camera_to_wrist = poseEigenToCal(params.camera_mount_to_camera_guess.inverse());
 
   ceres::Problem problem;
 
@@ -248,8 +248,8 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem3D3D& params)
 
   ExtrinsicHandEyeResult result;
   result.converged = summary.termination_type == ceres::CONVERGENCE;
-  result.base_to_target = poseCalToEigen(internal_base_to_target);
-  result.wrist_to_camera = poseCalToEigen(internal_camera_to_wrist).inverse();
+  result.target_mount_to_target = poseCalToEigen(internal_base_to_target);
+  result.camera_mount_to_camera = poseCalToEigen(internal_camera_to_wrist).inverse();
   result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
   result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
 

--- a/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
+++ b/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
@@ -199,6 +199,7 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D& params)
   }
 
   ceres::Solver::Options options;
+  options.max_num_iterations = 150;
   ceres::Solver::Summary summary;
 
   ceres::Solve(options, &problem, &summary);

--- a/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
+++ b/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
@@ -216,11 +216,11 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D& params)
       // Define
       const auto& img_obs = correspondence.in_image;
       const auto& point_in_target = correspondence.in_target;
-      const auto wrist_to_base = observation.base_to_camera_mount.inverse();
+      const auto wrist_to_base = observation.to_camera_mount.inverse();
 
       // Allocate Ceres data structures - ownership is taken by the ceres
       // Problem data structure
-      auto* cost_fn = new ObservationCost2D3D(img_obs, wrist_to_base, observation.base_to_target_mount, point_in_target, params.intr);
+      auto* cost_fn = new ObservationCost2D3D(img_obs, wrist_to_base, observation.to_target_mount, point_in_target, params.intr);
 
       auto* cost_block = new ceres::AutoDiffCostFunction<ObservationCost2D3D, 2, 6, 6>(cost_fn);
 
@@ -259,11 +259,11 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem3D3D& params)
       // Define
       const auto& img_obs = correspondence.in_image;
       const auto& point_in_target = correspondence.in_target;
-      const auto wrist_to_base = observation.base_to_camera_mount.inverse();
+      const auto wrist_to_base = observation.to_camera_mount.inverse();
 
       // Allocate Ceres data structures - ownership is taken by the ceres
       // Problem data structure
-      auto* cost_fn = new ObservationCost3D3D(img_obs, wrist_to_base, observation.base_to_target_mount, point_in_target);
+      auto* cost_fn = new ObservationCost3D3D(img_obs, wrist_to_base, observation.to_target_mount, point_in_target);
 
       auto* cost_block = new ceres::AutoDiffCostFunction<ObservationCost3D3D, 3, 6, 6>(cost_fn);
 

--- a/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
+++ b/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp
@@ -1,0 +1,289 @@
+#include "rct_optimizations/extrinsic_hand_eye.h"
+
+#include "rct_optimizations/ceres_math_utilities.h"
+#include "rct_optimizations/eigen_conversions.h"
+#include "rct_optimizations/types.h"
+
+#include <ceres/ceres.h>
+#include <iostream>
+
+using namespace rct_optimizations;
+
+namespace
+{
+template<Eigen::Index OBS_DIMENSION>
+class ObservationCost
+{
+public:
+  /**
+    * @brief A Ceres cost function class that represents a single observation of a 3D camera and target
+    * @param obs - The observation of a feature in the camera frame
+    * @param camera_mount_to_base - The transform from the camera "mount" frame to the common base frame
+    * @param base_to_target_mount - The transform from the common base frame to the target "mount" frame
+    * @param point_in_target - The corresponding feature in the target frame
+    */
+  ObservationCost(const Eigen::Matrix<double, OBS_DIMENSION, 1> &obs,
+                  const Eigen::Isometry3d &camera_mount_to_base,
+                  const Eigen::Isometry3d &base_to_target_mount,
+                  const Eigen::Vector3d &point_in_target)
+    : obs_(obs)
+    , camera_mount_to_base_(poseEigenToCal(camera_mount_to_base))
+    , base_to_target_mount_(poseEigenToCal(base_to_target_mount))
+    , target_pt_(point_in_target)
+  {
+  }
+
+  template<typename T>
+  bool operator()(const T * pose_camera_to_camera_mount,
+                  const T * pose_target_mount_to_target,
+                  T * residual) const;
+
+protected:
+  template<typename T>
+  void getTargetPointInCamera(const T *pose_camera_to_camera_mount,
+                              const T *pose_target_mount_to_target,
+                              T* camera_point) const
+  {
+    const T *camera_angle_axis = pose_camera_to_camera_mount + 0;
+    const T *camera_position = pose_camera_to_camera_mount + 3;
+
+    const T *target_angle_axis = pose_target_mount_to_target + 0;
+    const T *target_position = pose_target_mount_to_target + 3;
+
+    T target_mount_point[3]; // Point in target mount coordinates
+    T world_point[3]; // Point in world coordinates
+    T camera_mount_point[3]; // Point in camera mount coordinates
+
+    // Transform points into camera coordinates
+    T target_pt[3];
+    target_pt[0] = T(target_pt_(0));
+    target_pt[1] = T(target_pt_(1));
+    target_pt[2] = T(target_pt_(2));
+    transformPoint(target_angle_axis, target_position, target_pt, target_mount_point);
+    poseTransformPoint(base_to_target_mount_, target_mount_point, world_point);
+    poseTransformPoint(camera_mount_to_base_, world_point, camera_mount_point);
+    transformPoint(camera_angle_axis, camera_position, camera_mount_point, camera_point);
+  }
+
+  Eigen::Matrix<double, OBS_DIMENSION, 1> obs_;
+  Pose6d camera_mount_to_base_;
+  Pose6d base_to_target_mount_;
+  Eigen::Vector3d target_pt_;
+};
+
+//template<>
+//class ObservationCost<2>
+//{
+//  ObservationCost(const Eigen::Vector3d &obs,
+//                  const Eigen::Isometry3d &camera_mount_to_base,
+//                  const Eigen::Isometry3d &base_to_target_mount,
+//                  const Eigen::Matrix<double, 2, 1> &point_in_target,
+//                  const CameraIntrinsics& intr)
+//    : obs_(obs)
+//    , camera_mount_to_base_(poseEigenToCal(camera_mount_to_base))
+//    , base_to_target_mount_(poseEigenToCal(base_to_target_mount))
+//    , target_pt_(point_in_target)
+//    , intr_(intr)
+//  {
+//  }
+
+//  template<typename T>
+//  bool operator()(const T *pose_camera_to_camera_mount,
+//                  const T *pose_target_mount_to_target,
+//                  T *residual) const
+//  {
+//    // Get the point in the frame of the camera
+//    T camera_point[3];
+//    getTargetPointInCamera(pose_camera_to_camera_mount, pose_target_mount_to_target, camera_point);
+
+//    // Project the point into the image
+//    T xy_image[2];
+//    projectPoint(intr_, camera_point, xy_image);
+
+//    // Calculate the residual error
+//    residual[0] = xy_image[0] - obs_.x();
+//    residual[1] = xy_image[1] - obs_.y();
+
+//    return true;
+//  }
+
+//  Eigen::Matrix<double, 2, 1> obs_;
+//  Pose6d camera_mount_to_base_;
+//  Pose6d base_to_target_mount_;
+//  Eigen::Vector3d target_pt_;
+//  CameraIntrinsics intr_;
+//};
+
+//template<>
+//template<typename T>
+//bool ObservationCost<3>::operator()(const T *pose_camera_to_camera_mount,
+//                                    const T *pose_target_mount_to_target,
+//                                    T *residual) const
+//{
+//  // Get the target point in the frame of the camera
+//  T camera_point[3];
+//  getTargetPointInCamera(pose_camera_to_camera_mount, pose_target_mount_to_target, camera_point);
+
+//  // Calculate the residual error
+//  residual[0] = camera_point[0] - obs_.x();
+//  residual[1] = camera_point[1] - obs_.y();
+//  residual[2] = camera_point[2] - obs_.z();
+
+//  return true;
+//}
+
+/**
+ * @brief The ObservationCost2D3D class
+ */
+class ObservationCost2D3D : public ObservationCost<2>
+{
+public:
+  ObservationCost2D3D(const Eigen::Vector2d &obs,
+                      const Eigen::Isometry3d &camera_mount_to_base,
+                      const Eigen::Isometry3d &base_to_target_mount,
+                      const Eigen::Vector3d &point_in_target,
+                      const CameraIntrinsics &intr)
+    : ObservationCost(obs, camera_mount_to_base, base_to_target_mount, point_in_target)
+    , intr_(intr)
+  {
+  }
+
+  template<typename T>
+  bool operator()(const T *pose_camera_to_camera_mount,
+                  const T *pose_target_mount_to_target,
+                  T *residual) const
+  {
+    // Get the point in the frame of the camera
+    T camera_point[3];
+    getTargetPointInCamera(pose_camera_to_camera_mount, pose_target_mount_to_target, camera_point);
+
+    // Project the point into the image
+    T xy_image[2];
+    projectPoint(intr_, camera_point, xy_image);
+
+    // Calculate the residual error
+    residual[0] = xy_image[0] - obs_.x();
+    residual[1] = xy_image[1] - obs_.y();
+
+    return true;
+  }
+
+  private:
+  CameraIntrinsics intr_;
+};
+
+/**
+ * @brief The ObservationCost3D3D class
+ */
+class ObservationCost3D3D : public ObservationCost<3>
+{
+public:
+  using ObservationCost<3>::ObservationCost;
+
+  template<typename T>
+  bool operator()(const T *pose_camera_to_camera_mount,
+                  const T *pose_target_mount_to_target,
+                  T *residual) const
+  {
+    // Get the target point in the frame of the camera
+    T camera_point[3];
+    getTargetPointInCamera(pose_camera_to_camera_mount, pose_target_mount_to_target, camera_point);
+
+    // Calculate the residual error
+    residual[0] = camera_point[0] - obs_.x();
+    residual[1] = camera_point[1] - obs_.y();
+    residual[2] = camera_point[2] - obs_.z();
+
+    return true;
+  }
+};
+
+} // namespace anonymous
+
+namespace rct_optimizations
+{
+ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D& params)
+{
+  Pose6d internal_base_to_target = poseEigenToCal(params.base_to_target_guess);
+  Pose6d internal_camera_to_wrist = poseEigenToCal(params.wrist_to_camera_guess.inverse());
+
+  ceres::Problem problem;
+
+  for (const auto &observation : params.observations)
+  {
+    for (const auto& correspondence : observation.correspondence_set)
+    {
+      // Define
+      const auto& img_obs = correspondence.in_image;
+      const auto& point_in_target = correspondence.in_target;
+      const auto wrist_to_base = observation.base_to_camera_mount.inverse();
+
+      // Allocate Ceres data structures - ownership is taken by the ceres
+      // Problem data structure
+      auto* cost_fn = new ObservationCost2D3D(img_obs, wrist_to_base, observation.base_to_target_mount, point_in_target, params.intr);
+
+      auto* cost_block = new ceres::AutoDiffCostFunction<ObservationCost2D3D, 2, 6, 6>(cost_fn);
+
+      problem.AddResidualBlock(cost_block, NULL, internal_camera_to_wrist.values.data(),
+                               internal_base_to_target.values.data());
+    }
+  }
+
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+
+  ceres::Solve(options, &problem, &summary);
+
+  ExtrinsicHandEyeResult result;
+  result.converged = summary.termination_type == ceres::CONVERGENCE;
+  result.base_to_target = poseCalToEigen(internal_base_to_target);
+  result.wrist_to_camera = poseCalToEigen(internal_camera_to_wrist).inverse();
+  result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
+  result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
+
+  return result;
+
+}
+
+ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem3D3D& params)
+{
+  Pose6d internal_base_to_target = poseEigenToCal(params.base_to_target_guess);
+  Pose6d internal_camera_to_wrist = poseEigenToCal(params.wrist_to_camera_guess.inverse());
+
+  ceres::Problem problem;
+
+  for (const auto &observation : params.observations)
+  {
+    for (const auto& correspondence : observation.correspondence_set)
+    {
+      // Define
+      const auto& img_obs = correspondence.in_image;
+      const auto& point_in_target = correspondence.in_target;
+      const auto wrist_to_base = observation.base_to_camera_mount.inverse();
+
+      // Allocate Ceres data structures - ownership is taken by the ceres
+      // Problem data structure
+      auto* cost_fn = new ObservationCost3D3D(img_obs, wrist_to_base, observation.base_to_target_mount, point_in_target);
+
+      auto* cost_block = new ceres::AutoDiffCostFunction<ObservationCost3D3D, 3, 6, 6>(cost_fn);
+
+      problem.AddResidualBlock(cost_block, NULL, internal_camera_to_wrist.values.data(),
+                               internal_base_to_target.values.data());
+    }
+  }
+
+  ceres::Solver::Options options;
+  ceres::Solver::Summary summary;
+
+  ceres::Solve(options, &problem, &summary);
+
+  ExtrinsicHandEyeResult result;
+  result.converged = summary.termination_type == ceres::CONVERGENCE;
+  result.base_to_target = poseCalToEigen(internal_base_to_target);
+  result.wrist_to_camera = poseCalToEigen(internal_camera_to_wrist).inverse();
+  result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
+  result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
+
+  return result;
+}
+} // namespace rct_optimizations

--- a/rct_optimizations/test/CMakeLists.txt
+++ b/rct_optimizations/test/CMakeLists.txt
@@ -27,11 +27,20 @@ rct_gtest_discover_tests(${PROJECT_NAME}_extrinsic_camera_on_wrist_tests)
 add_dependencies(${PROJECT_NAME}_extrinsic_camera_on_wrist_tests ${PROJECT_NAME})
 add_dependencies(run_tests ${PROJECT_NAME}_extrinsic_camera_on_wrist_tests)
 
+add_executable(${PROJECT_NAME}_extrinsic_hand_eye_tests extrinsic_hand_eye_utest.cpp)
+target_link_libraries(${PROJECT_NAME}_extrinsic_hand_eye_tests PRIVATE ${PROJECT_NAME}_test_support GTest::GTest GTest::Main)
+rct_gtest_discover_tests(${PROJECT_NAME}_extrinsic_hand_eye_tests)
+add_dependencies(${PROJECT_NAME}_extrinsic_hand_eye_tests ${PROJECT_NAME})
+add_dependencies(run_tests ${PROJECT_NAME}_extrinsic_hand_eye_tests)
+
 # Install the test executables so they can be run independently later if needed
-install(TARGETS
-          ${PROJECT_NAME}_conversion_tests
-          ${PROJECT_NAME}_extrinsic_multi_static_camera_tests
-          ${PROJECT_NAME}_extrinsic_camera_on_wrist_tests
-        RUNTIME DESTINATION bin/tests
-        LIBRARY DESTINATION lib/tests
-        ARCHIVE DESTINATION lib/tests)
+install(
+  TARGETS
+    ${PROJECT_NAME}_conversion_tests
+    ${PROJECT_NAME}_extrinsic_multi_static_camera_tests
+    ${PROJECT_NAME}_extrinsic_camera_on_wrist_tests
+    ${PROJECT_NAME}_extrinsic_hand_eye_tests
+  RUNTIME DESTINATION bin/tests
+  LIBRARY DESTINATION lib/tests
+  ARCHIVE DESTINATION lib/tests
+)

--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -138,7 +138,7 @@ class HandEyeTest : public ::testing::Test
   HandEyeTest()
     : true_target_mount_to_target(Eigen::Isometry3d::Identity())
     , true_camera_mount_to_camera(Eigen::Isometry3d::Identity())
-    , target(7, 5, 0.025)
+    , target(5, 7, 0.025)
   {
     true_target_mount_to_target.translate(Eigen::Vector3d(1.0, 0, 0.0));
 

--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -1,0 +1,135 @@
+#include <gtest/gtest.h>
+#include <rct_optimizations/extrinsic_hand_eye.h>
+#include <rct_optimizations/ceres_math_utilities.h>
+
+// Test utilities
+#include <rct_optimizations_tests/utilities.h>
+#include <rct_optimizations_tests/observation_creator.h>
+
+using namespace rct_optimizations;
+
+namespace
+{
+static void printResults(const ExtrinsicHandEyeResult& r)
+{
+  // Report results
+  std::cout << "Did converge?: " << r.converged << "\n";
+  std::cout << "Initial cost?: " << r.initial_cost_per_obs << "\n";
+  std::cout << "Final cost?: " << r.final_cost_per_obs << "\n";
+
+  Eigen::Isometry3d c = r.wrist_to_camera;
+  Eigen::Isometry3d t = r.base_to_target;
+
+  std::cout << "Wrist to Camera:\n";
+  std::cout << c.matrix() << "\n";
+  std::cout << "Base to Target:\n";
+  std::cout << t.matrix() << "\n";
+}
+
+enum class InitialConditions
+{
+  PERFECT, IDENTITY_TARGET, RANDOM_AROUND_ANSWER
+};
+
+} // namespace anonymous
+
+void run_test(InitialConditions condition)
+{
+  test::Target grid(5, 7, 0.025);
+
+  // Define the "true" conditions
+  auto true_base_to_target = Eigen::Isometry3d::Identity();
+  true_base_to_target.translation() = Eigen::Vector3d(1.0, 0, 0);
+
+  auto true_wrist_to_camera = Eigen::Isometry3d::Identity();
+  true_wrist_to_camera.translation() = Eigen::Vector3d(0.05, 0, 0.1);
+  true_wrist_to_camera.linear() <<  0,  0,  1,
+                                   -1,  0,  0,
+                                    0, -1,  0;
+
+  // Set up the calibration problem
+  ExtrinsicHandEyeProblem3D3D problem;
+
+  // Create some number of "test" images...
+  // We'll take pictures in a grid above the origin of the target
+  for (int i = -5; i < 5; ++i)
+  {
+    for (int j = -5; j < 5; ++j)
+    {
+      Eigen::Vector3d center_point = true_base_to_target.translation() + Eigen::Vector3d(i * 0.025, j * 0.025, 1.0);
+      Eigen::Isometry3d camera_pose = test::lookAt(center_point,
+                                                   true_base_to_target.translation(),
+                                                   Eigen::Vector3d(1, 0, 0));
+      Eigen::Isometry3d wrist_pose = camera_pose * true_wrist_to_camera.inverse();
+
+      // Attempt to generate points
+      try
+      {
+        Observation3D3D obs;
+        obs.correspondence_set = getCorrespondences(camera_pose, true_base_to_target, grid);
+        obs.base_to_camera_mount = wrist_pose;
+        problem.observations.push_back(obs);
+      }
+      catch (const std::exception& ex)
+      {
+        continue;
+      }
+    }
+  }
+
+  // Set the initial guess
+  if (condition == InitialConditions::PERFECT)
+  {
+    problem.base_to_target_guess = true_base_to_target;
+    problem.wrist_to_camera_guess = true_wrist_to_camera;
+  }
+  else if (condition == InitialConditions::IDENTITY_TARGET)
+  {
+    problem.base_to_target_guess.setIdentity();
+    problem.wrist_to_camera_guess = true_wrist_to_camera;
+  }
+  else // condition == RANDOM
+  {
+    const double spatial_noise = 0.25; // +/- 0.25 meters
+    const double angular_noise = 45. * M_PI / 180.0; // +/- 45 degrees
+    problem.base_to_target_guess = test::perturbPose(true_base_to_target, spatial_noise, angular_noise);
+    problem.wrist_to_camera_guess = test::perturbPose(true_wrist_to_camera, spatial_noise, angular_noise);
+    std::cout << "initial base to target:\n" << problem.base_to_target_guess.matrix() << "\n";
+    std::cout << "initial wrist to camera:\n" << problem.wrist_to_camera_guess.matrix() << "\n";
+  }
+
+  // Run the optimization
+  auto result = optimize(problem);
+
+  // Make sure it converged to the correct answer
+  EXPECT_TRUE(result.converged);
+  EXPECT_TRUE(result.final_cost_per_obs < 1.0);
+
+  EXPECT_TRUE(result.base_to_target.isApprox(true_base_to_target, 1e-6));
+  EXPECT_TRUE(result.wrist_to_camera.isApprox(true_wrist_to_camera, 1e-6));
+
+  printResults(result);
+}
+
+TEST(HandEye3D, perfect_start)
+{
+  run_test(InitialConditions::PERFECT);
+}
+
+TEST(HandEye3D, identity_target_start)
+{
+  run_test(InitialConditions::IDENTITY_TARGET);
+}
+
+TEST(HandEye3D, perturbed_start)
+{
+  // Run 10 random tests
+  for (int i = 0; i < 10; ++i)
+    run_test(InitialConditions::RANDOM_AROUND_ANSWER);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -178,7 +178,8 @@ TYPED_TEST(HandEyeTest, PerfectInitialConditions)
                                                             this->target,
                                                             InitialConditions::PERFECT);
   // Run the optimization
-  auto result = optimize(prob);
+  ExtrinsicHandEyeResult result;
+  EXPECT_NO_THROW(result = optimize(prob));
 
   // Make sure it converged to the correct answer
   EXPECT_TRUE(result.converged);
@@ -200,7 +201,8 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions)
                                                  this->target,
                                                  InitialConditions::RANDOM_AROUND_ANSWER);
     // Run the optimization
-    auto result = optimize(prob);
+    ExtrinsicHandEyeResult result;
+    EXPECT_NO_THROW(result = optimize(prob));
 
     // Make sure it converged to the correct answer
     EXPECT_TRUE(result.converged);

--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -57,8 +57,8 @@ ExtrinsicHandEyeProblem2D3D ProblemCreator<ExtrinsicHandEyeProblem2D3D>::createP
 
   ExtrinsicHandEyeProblem2D3D problem;
   problem.intr = camera.intr;
-  problem.base_to_target_guess = createPose(true_target, init);
-  problem.wrist_to_camera_guess = createPose(true_camera, init);
+  problem.target_mount_to_target_guess = createPose(true_target, init);
+  problem.camera_mount_to_camera_guess = createPose(true_camera, init);
 
   // Create observations
   for (int i = -5; i < 5; ++i)
@@ -102,8 +102,8 @@ ExtrinsicHandEyeProblem3D3D ProblemCreator<ExtrinsicHandEyeProblem3D3D>::createP
   const InitialConditions &init)
 {
   ExtrinsicHandEyeProblem3D3D problem;
-  problem.base_to_target_guess = createPose(true_target, init);
-  problem.wrist_to_camera_guess = createPose(true_camera, init);
+  problem.target_mount_to_target_guess = createPose(true_target, init);
+  problem.camera_mount_to_camera_guess = createPose(true_camera, init);
 
   // Create observations
   for (int i = -5; i < 5; ++i)
@@ -153,8 +153,8 @@ class HandEyeTest : public ::testing::Test
     std::cout << "Initial cost?: " << r.initial_cost_per_obs << "\n";
     std::cout << "Final cost?: " << r.final_cost_per_obs << "\n";
 
-    Eigen::Isometry3d c = r.wrist_to_camera;
-    Eigen::Isometry3d t = r.base_to_target;
+    Eigen::Isometry3d c = r.camera_mount_to_camera;
+    Eigen::Isometry3d t = r.target_mount_to_target;
 
     std::cout << "Wrist to Camera:\n";
     std::cout << c.matrix() << "\n";
@@ -185,8 +185,8 @@ TYPED_TEST(HandEyeTest, PerfectInitialConditions)
   EXPECT_TRUE(result.converged);
   EXPECT_TRUE(result.final_cost_per_obs < ProblemCreator<TypeParam>::max_cost_per_obs);
 
-  EXPECT_TRUE(result.base_to_target.isApprox(this->true_target_mount_to_target, 1e-6));
-  EXPECT_TRUE(result.wrist_to_camera.isApprox(this->true_camera_mount_to_camera, 1e-6));
+  EXPECT_TRUE(result.target_mount_to_target.isApprox(this->true_target_mount_to_target, 1e-6));
+  EXPECT_TRUE(result.camera_mount_to_camera.isApprox(this->true_camera_mount_to_camera, 1e-6));
 
   this->printResults(result);
 }
@@ -208,8 +208,8 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions)
     EXPECT_TRUE(result.converged);
     EXPECT_TRUE(result.final_cost_per_obs < ProblemCreator<TypeParam>::max_cost_per_obs);
 
-    EXPECT_TRUE(result.base_to_target.isApprox(this->true_target_mount_to_target, 1e-6));
-    EXPECT_TRUE(result.wrist_to_camera.isApprox(this->true_camera_mount_to_camera, 1e-6));
+    EXPECT_TRUE(result.target_mount_to_target.isApprox(this->true_target_mount_to_target, 1e-6));
+    EXPECT_TRUE(result.camera_mount_to_camera.isApprox(this->true_camera_mount_to_camera, 1e-6));
 
     this->printResults(result);
   }

--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -229,6 +229,8 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions)
 
     this->printResults(result);
   }
+  EXPECT_EQ(count, n);
+  EXPECT_LT(count, max_attempts);
 }
 
 int main(int argc, char **argv)

--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -67,7 +67,7 @@ void run_test(InitialConditions condition)
       {
         Observation3D3D obs;
         obs.correspondence_set = getCorrespondences(camera_pose, true_base_to_target, grid);
-        obs.base_to_camera_mount = wrist_pose;
+        obs.to_camera_mount = wrist_pose;
         problem.observations.push_back(obs);
       }
       catch (const std::exception& ex)

--- a/rct_optimizations/test/include/rct_optimizations_tests/observation_creator.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/observation_creator.h
@@ -19,11 +19,11 @@ namespace test
  * @return A set of all "seen" correspondences
  * @throws Exception if @ref require_all is true and not all observations are seen
  */
-CorrespondenceSet getCorrespondences(const Eigen::Isometry3d &camera_pose,
-                                     const Eigen::Isometry3d &target_pose,
-                                     const Camera &camera,
-                                     const Target &target,
-                                     const bool require_all = false);
+Correspondence2D3D::Set getCorrespondences(const Eigen::Isometry3d &camera_pose,
+                                           const Eigen::Isometry3d &target_pose,
+                                           const Camera &camera,
+                                           const Target &target,
+                                           const bool require_all = false);
 
 /**
  * @brief Observes a set of simulated 3D-3D correspondences given a target definition.
@@ -33,9 +33,9 @@ CorrespondenceSet getCorrespondences(const Eigen::Isometry3d &camera_pose,
  * @param target - the observation target definition
  * @return
  */
-Correspondence3DSet getCorrespondences(const Eigen::Isometry3d &camera_pose,
-                                       const Eigen::Isometry3d &target_pose,
-                                       const Target &target) noexcept;
+Correspondence3D3D::Set getCorrespondences(const Eigen::Isometry3d &camera_pose,
+                                           const Eigen::Isometry3d &target_pose,
+                                           const Target &target) noexcept;
 
 /**
  * @brief Defines a camera matrix using a camera origin, a position its looking at, and an up vector hint

--- a/rct_optimizations/test/src/observation_creator.cpp
+++ b/rct_optimizations/test/src/observation_creator.cpp
@@ -17,13 +17,13 @@ namespace rct_optimizations
 {
 namespace test
 {
-CorrespondenceSet getCorrespondences(const Eigen::Isometry3d &camera_pose,
-                                     const Eigen::Isometry3d &target_pose,
-                                     const Camera &camera,
-                                     const Target &target,
-                                     const bool require_all)
+Correspondence2D3D::Set getCorrespondences(const Eigen::Isometry3d &camera_pose,
+                                           const Eigen::Isometry3d &target_pose,
+                                           const Camera &camera,
+                                           const Target &target,
+                                           const bool require_all)
 {
-  CorrespondenceSet correspondences;
+  Correspondence2D3D::Set correspondences;
   correspondences.reserve(target.points.size());
 
   Eigen::Isometry3d camera_to_target = camera_pose.inverse() * target_pose;
@@ -52,11 +52,11 @@ CorrespondenceSet getCorrespondences(const Eigen::Isometry3d &camera_pose,
 }
 
 
-Correspondence3DSet getCorrespondences(const Eigen::Isometry3d &camera_pose,
-                                       const Eigen::Isometry3d &target_pose,
-                                       const Target &target) noexcept
+Correspondence3D3D::Set getCorrespondences(const Eigen::Isometry3d &camera_pose,
+                                           const Eigen::Isometry3d &target_pose,
+                                           const Target &target) noexcept
 {
-  Correspondence3DSet correspondences;
+  Correspondence3D3D::Set correspondences;
   correspondences.reserve(target.points.size());
 
   Eigen::Isometry3d camera_to_target = camera_pose.inverse() * target_pose;


### PR DESCRIPTION
This PR refactors the way that correspondences and observations are structured for easier use in testing utilities and optimization problems.

## Proposed Structure
- Observation[ ] (i.e. observation set)
  - Observation
    - Correspondence[ ] (i.e. correspondence set)
      - Correspondence
        - Point in target
        - Point in image
    - Camera pose (wrist pose if camera is moving, identity otherwise)
    - Target pose (wrist pose if target is moving, identity otherwise)

## Motivation
Currently, a class for the observation does not exist. The optimization problems require vectors of correspondence sets and wrist poses with the assumption they are the same length and are associated by index with one another. It makes more sense to couple these together in a struct since the correspondence set is directly associated with the pose at which the sensor data was acquired.

An additional shortcoming of the current implementation is that the optimization classes do not provide members for the "wrist" poses of the target. A static-camera-moving-target problem is defined a separate problem from moving-camera-static-target, when in fact they can be the same. The proposed change adds a member for the transform to the target. This makes the representation of the observation more complete/unambiguous and allows duplicated cost functions to be consolidated.

The creation of the observation structure will also help improve the creation of simulated calibration data for unit testing of the algorithms

## Example
As an example, I refactored the `extrinsic_3d_camera_on_wrist`, `extrinsic_camera_on_wrist`, and `extrinsic_static_camera` into a single, more unified `extrinsic_hand_eye` problem which supports all those types of calibration and utilizes the new `Observation` structure. I still need to implement a few more unit tests to prove these out, but they should work correctly.

@Levi-Armstrong @schornakj @drchrislewis can you review the proposed [`Observation` class](https://github.com/marip8/robot_cal_tools/blob/e3e4f9b540dba80e113963de5214dfacdc34c9af/rct_optimizations/include/rct_optimizations/types.h) and hand-eye implementation ([header](https://github.com/marip8/robot_cal_tools/blob/e3e4f9b540dba80e113963de5214dfacdc34c9af/rct_optimizations/include/rct_optimizations/extrinsic_hand_eye.h) and [source](https://github.com/marip8/robot_cal_tools/blob/e3e4f9b540dba80e113963de5214dfacdc34c9af/rct_optimizations/src/rct_optimizations/extrinsic_hand_eye.cpp))? I would like to know if this is a change worth adding into the repository, as it would be a breaking change when the optimization problems are updated.

Builds on #37 