### PR TITLE
Fix eigen build issue

### DIFF
--- a/rct_examples/CMakeLists.txt
+++ b/rct_examples/CMakeLists.txt
@@ -11,6 +11,11 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(OpenCV REQUIRED)
+find_package(Eigen3 REQUIRED)
+# Eigen 3.2 (Wily) only provides EIGEN3_INCLUDE_DIR, not EIGEN3_INCLUDE_DIRS
+if(NOT EIGEN3_INCLUDE_DIRS)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
 
 # This package only provides examples. It does not export any tools.
 catkin_package()
@@ -21,6 +26,7 @@ catkin_package()
 
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 #####################

--- a/rct_image_tools/CMakeLists.txt
+++ b/rct_image_tools/CMakeLists.txt
@@ -7,6 +7,11 @@ find_package(OpenCV REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   rct_optimizations
 )
+find_package(Eigen3 REQUIRED)
+# Eigen 3.2 (Wily) only provides EIGEN3_INCLUDE_DIR, not EIGEN3_INCLUDE_DIRS
+if(NOT EIGEN3_INCLUDE_DIRS)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
 
 catkin_package(
   INCLUDE_DIRS
@@ -18,6 +23,7 @@ catkin_package(
     rct_optimizations
   DEPENDS
     OpenCV
+    Eigen3
 )
 
 ###########
@@ -27,6 +33,7 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 # Declare a C++ library


### PR DESCRIPTION
Without these changes It fails to find the **Eigen/Dense** header in `rct_examples` and `rct_image_tools` in ROS melodic