### PR TITLE
Convert rct_optimizations to be a ROS-generic CMake package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,15 @@ jobs:
              OS_CODE_NAME: bionic,
              ROS_DISTRO: melodic,
              ROS_REPO: main,
+             ADDITIONAL_DEBS: git,
+             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=True",
              BADGE: bionic}
           - {OS_NAME: ubuntu,
              OS_CODE_NAME: xenial,
              ROS_DISTRO: kinetic,
              ROS_REPO: main,
+             ADDITIONAL_DEBS: git,
+             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=True",
              BADGE: xenial}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,14 @@ jobs:
              ROS_DISTRO: melodic,
              ROS_REPO: main,
              ADDITIONAL_DEBS: git,
-             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=True",
+             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=True -DRCT_RUN_TESTS=True",
              BADGE: bionic}
           - {OS_NAME: ubuntu,
              OS_CODE_NAME: xenial,
              ROS_DISTRO: kinetic,
              ROS_REPO: main,
              ADDITIONAL_DEBS: git,
-             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=True",
+             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=True -DRCT_RUN_TESTS=True",
              BADGE: xenial}
     runs-on: ubuntu-latest
     steps:

--- a/rct_common/CMakeLists.txt
+++ b/rct_common/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(rct_common VERSION 0.1.0)
+
+include(cmake/rct_macros.cmake)
+
+if(RCT_BUILD_TESTS)
+  find_package(GTest QUIET)
+  if ( NOT GTest_FOUND )
+
+    include(ExternalProject)
+
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set(GTEST_CXX_FLAGS "-w -std=c++14")
+      set(GTEST_C_FLAGS "-w")
+
+      ExternalProject_Add(GTest
+        GIT_REPOSITORY    https://github.com/google/googletest.git
+        GIT_TAG           release-1.8.1
+        SOURCE_DIR        ${CMAKE_BINARY_DIR}/../rct_common/googletest-src
+        BINARY_DIR        ${CMAKE_BINARY_DIR}/../rct_common/googletest-build
+        CMAKE_CACHE_ARGS
+                -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
+                -DCMAKE_BUILD_TYPE:STRING=Release
+                -DCMAKE_CXX_FLAGS:STRING=${GTEST_CXX_FLAGS}
+                -DCMAKE_C_FLAGS:STRING=${GTEST_C_FLAGS}
+                -DBUILD_GMOCK:BOOL=OFF
+                -DBUILD_GTEST:BOOL=ON
+                -DBUILD_SHARED_LIBS:BOOL=ON
+      )
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      ExternalProject_Add(GTest
+        GIT_REPOSITORY    https://github.com/google/googletest.git
+        GIT_TAG           release-1.8.1
+        SOURCE_DIR        ${CMAKE_BINARY_DIR}/../rct_common/googletest-src
+        BINARY_DIR        ${CMAKE_BINARY_DIR}/../rct_common/googletest-build
+        CMAKE_CACHE_ARGS
+                -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
+                -DCMAKE_BUILD_TYPE:STRING=Release
+                -DBUILD_GMOCK:BOOL=OFF
+                -DBUILD_GTEST:BOOL=ON
+                -DBUILD_SHARED_LIBS:BOOL=ON
+      )
+    endif()
+  endif()
+endif()
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+rct_configure_package(${PROJECT_NAME})
+
+install(FILES
+  "${CMAKE_CURRENT_LIST_DIR}/cmake/rct_macros.cmake"
+  DESTINATION lib/cmake/${PROJECT_NAME})

--- a/rct_common/cmake/rct_common-config.cmake.in
+++ b/rct_common/cmake/rct_common-config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+set(@PROJECT_NAME@_FOUND ON)
+set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/rct_macros.cmake")
+

--- a/rct_common/cmake/rct_macros.cmake
+++ b/rct_common/cmake/rct_macros.cmake
@@ -1,0 +1,58 @@
+# Performs multiple operation so other packages may find a package
+# Adapted from the Tesseract CMake macros
+# Usage: rct_configure_package(targetA targetB ...)
+#   * It installs the provided targets
+#   * It exports the provided targets under the namespace rct::
+#   * It installs the package.xml file
+#   * It create and install the ${PROJECT_NAME}-config.cmake and ${PROJECT_NAME}-config-version.cmake
+macro(rct_configure_package)
+  install(TARGETS ${ARGV}
+          EXPORT ${PROJECT_NAME}-targets
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION lib
+          ARCHIVE DESTINATION lib)
+  install(EXPORT ${PROJECT_NAME}-targets NAMESPACE rct:: DESTINATION lib/cmake/${PROJECT_NAME})
+
+  install(FILES package.xml DESTINATION share/${PROJECT_NAME})
+
+  # Create cmake config files
+  include(CMakePackageConfigHelpers)
+  configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/${PROJECT_NAME}-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+  write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion)
+
+  install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+    DESTINATION lib/cmake/${PROJECT_NAME})
+
+  export(EXPORT ${PROJECT_NAME}-targets NAMESPACE rct:: FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-targets.cmake)
+endmacro()
+
+# This macro call the appropriate gtest function to add a test based on the cmake version
+# Usage: rct_gtest_discover_tests(target)
+macro(rct_gtest_discover_tests target)
+  if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
+    gtest_add_tests(${target} "" AUTO)
+  else()
+    gtest_discover_tests(${target})
+  endif()
+endmacro()
+
+# This macro add a custom target that will run the tests after they are finished building when
+# RCT_RUN_TESTS is enabled
+# This is added to allow ability do disable the running of tests as part of the build for CI which calls make test
+macro(rct_add_run_tests_target)
+  if(RCT_RUN_TESTS)
+    add_custom_target(run_tests ALL
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND ${CMAKE_CTEST_COMMAND} -V -O "/tmp/${PROJECT_NAME}_ctest.log" -C $<CONFIGURATION>)
+  else()
+    add_custom_target(run_tests)
+  endif()
+endmacro()
+

--- a/rct_common/package.xml
+++ b/rct_common/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>rct_common</name>
+  <version>0.1.0</version>
+  <description>The rct_common package. Contains macros and external libraries for the robot_cal_tools project.</description>
+  <maintainer email="joseph.schornak@swri.org">Joseph Schornak</maintainer>
+  <author email="joseph.schornak@swri.org">Joseph Schornak</author>
+  <license>Apache 2.0</license>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/rct_examples/CMakeLists.txt
+++ b/rct_examples/CMakeLists.txt
@@ -1,11 +1,12 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.0)
 project(rct_examples)
 
 add_compile_options(-std=c++11 -Wall -Wextra)
 
+find_package(rct_optimizations REQUIRED)
+
 find_package(catkin REQUIRED COMPONENTS
   rct_image_tools
-  rct_optimizations
   rct_ros_tools
   roslib
 )
@@ -38,7 +39,7 @@ set_target_properties(${PROJECT_NAME}_wrist_example PROPERTIES OUTPUT_NAME examp
 
 add_dependencies(${PROJECT_NAME}_wrist_example ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_wrist_example ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_wrist_example ${catkin_LIBRARIES} rct::rct_optimizations)
 
 ###############################
 ## Offline Calibration Tools ##
@@ -50,7 +51,7 @@ set_target_properties(${PROJECT_NAME}_moving_camera PROPERTIES OUTPUT_NAME movin
 
 add_dependencies(${PROJECT_NAME}_moving_camera ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_moving_camera ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_moving_camera ${catkin_LIBRARIES} rct::rct_optimizations)
 
 # Executable for demonstrating extrinsic cal of static camera, moving target functionality
 add_executable(${PROJECT_NAME}_static_camera src/tools/static_camera_extrinsic.cpp)
@@ -59,7 +60,7 @@ set_target_properties(${PROJECT_NAME}_static_camera PROPERTIES OUTPUT_NAME stati
 
 add_dependencies(${PROJECT_NAME}_static_camera ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_static_camera ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_static_camera ${catkin_LIBRARIES} rct::rct_optimizations)
 
 # Executable for demonstrating extrinsic cal of multiple static camera, moving target functionality
 add_executable(${PROJECT_NAME}_multi_static_camera src/tools/multi_static_camera_extrinsic.cpp)
@@ -68,7 +69,7 @@ set_target_properties(${PROJECT_NAME}_multi_static_camera PROPERTIES OUTPUT_NAME
 
 add_dependencies(${PROJECT_NAME}_multi_static_camera ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_multi_static_camera ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_multi_static_camera ${catkin_LIBRARIES} rct::rct_optimizations)
 
 # Executable for demonstrating extrinsic cal of multiple static camera multi step, moving target functionality
 # First it calibrates the cameras to each other then it calibrates the set of camera where there relationship
@@ -79,7 +80,7 @@ set_target_properties(${PROJECT_NAME}_multi_static_camera_multi_step PROPERTIES 
 
 add_dependencies(${PROJECT_NAME}_multi_static_camera_multi_step ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_multi_static_camera_multi_step ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_multi_static_camera_multi_step ${catkin_LIBRARIES} rct::rct_optimizations)
 
 #Executable for demonstrating intrinsic calibration of a camera
 add_executable(${PROJECT_NAME}_intr src/tools/intrinsic_calibration.cpp)
@@ -88,7 +89,7 @@ set_target_properties(${PROJECT_NAME}_intr PROPERTIES OUTPUT_NAME intr_camera_ca
 
 add_dependencies(${PROJECT_NAME}_intr ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_intr ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_intr ${catkin_LIBRARIES} rct::rct_optimizations)
 
 # Executable demonstrating solving for the pose of a target given camera properties
 add_executable(${PROJECT_NAME}_pnp src/tools/solve_pnp.cpp)
@@ -97,7 +98,7 @@ set_target_properties(${PROJECT_NAME}_pnp PROPERTIES OUTPUT_NAME solve_pnp_ex PR
 
 add_dependencies(${PROJECT_NAME}_pnp ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_pnp ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_pnp ${catkin_LIBRARIES} rct::rct_optimizations)
 
 # Executable demonstrating solving for the pose of a target given multiple camera properties
 add_executable(${PROJECT_NAME}_multi_camera_pnp src/tools/solve_multi_camera_pnp.cpp)
@@ -106,16 +107,17 @@ set_target_properties(${PROJECT_NAME}_multi_camera_pnp PROPERTIES OUTPUT_NAME so
 
 add_dependencies(${PROJECT_NAME}_multi_camera_pnp ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_multi_camera_pnp ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_multi_camera_pnp ${catkin_LIBRARIES} rct::rct_optimizations)
 
 #############
 ## Testing ##
 #############
 if(CATKIN_ENABLE_TESTING)
+  find_package(GTest REQUIRED)
   # Tests extrinsic wrist calibration example
   catkin_add_gtest(${PROJECT_NAME}_wrist_test src/examples/camera_on_wrist.cpp)
   target_compile_definitions(${PROJECT_NAME}_wrist_test PRIVATE -DRCT_ENABLE_TESTING)
-  target_link_libraries(${PROJECT_NAME}_wrist_test ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_wrist_test ${catkin_LIBRARIES} rct::rct_optimizations GTest::GTest GTest::Main)
 endif()
 
 #############

--- a/rct_image_tools/CMakeLists.txt
+++ b/rct_image_tools/CMakeLists.txt
@@ -1,12 +1,13 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.0)
 project(rct_image_tools)
 
 add_compile_options(-std=c++11 -Wall -Wextra)
 
 find_package(OpenCV REQUIRED)
-find_package(catkin REQUIRED COMPONENTS
-  rct_optimizations
-)
+find_package(rct_optimizations REQUIRED)
+
+find_package(catkin REQUIRED)
+
 find_package(Eigen3 REQUIRED)
 # Eigen 3.2 (Wily) only provides EIGEN3_INCLUDE_DIR, not EIGEN3_INCLUDE_DIRS
 if(NOT EIGEN3_INCLUDE_DIRS)
@@ -19,8 +20,6 @@ catkin_package(
   LIBRARIES
     ${PROJECT_NAME}
     yaml-cpp
-  CATKIN_DEPENDS
-    rct_optimizations
   DEPENDS
     OpenCV
     Eigen3
@@ -50,6 +49,7 @@ target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${OpenCV_LIBRARIES}
   yaml-cpp
+  rct::rct_optimizations
 )
 
 add_executable(${PROJECT_NAME}_test
@@ -61,6 +61,7 @@ add_dependencies(${PROJECT_NAME}_test ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catk
 target_link_libraries(${PROJECT_NAME}_test
   ${catkin_LIBRARIES}
   ${PROJECT_NAME}
+  rct::rct_optimizations
 )
 
 #############

--- a/rct_optimizations/CMakeLists.txt
+++ b/rct_optimizations/CMakeLists.txt
@@ -1,31 +1,10 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(rct_optimizations)
+cmake_minimum_required(VERSION 3.5.0)
+project(rct_optimizations VERSION 0.1.0 LANGUAGES CXX)
 
-add_compile_options(-std=c++11 -Wall -Wextra)
-
-find_package(catkin REQUIRED)
+find_package(rct_common REQUIRED)
 find_package(Ceres REQUIRED)
 
-catkin_package(
-  INCLUDE_DIRS
-    include
-    ${CERES_INCLUDE_DIRS}
-  LIBRARIES
-    ${PROJECT_NAME}
-  DEPENDS
-    CERES
-)
-
-###########
-## Build ##
-###########
-
-include_directories(
-  include
-  ${CERES_INCLUDE_DIRS}
-)
-
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   # Utilities
   src/${PROJECT_NAME}/eigen_conversions.cpp
   # Optimizations (monocular camera)
@@ -42,49 +21,26 @@ add_library(${PROJECT_NAME}
   src/${PROJECT_NAME}/pnp.cpp
   src/${PROJECT_NAME}/multi_camera_pnp.cpp
 )
-
-add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
+target_compile_options(${PROJECT_NAME} PUBLIC -std=c++11)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
+  ${CERES_INCLUDE_DIRS}
+)
+target_link_libraries(${PROJECT_NAME} PUBLIC
   ${CERES_LIBRARIES}
 )
 
-#############
-## Testing ##
-#############
-if(CATKIN_ENABLE_TESTING)
-  # Build the test support library
-  add_library(${PROJECT_NAME}_test_support
-    test/src/pose_generator.cpp
-    test/src/observation_creator.cpp
-    test/src/utilities.cpp)
-  target_link_libraries(${PROJECT_NAME}_test_support ${PROJECT_NAME})
-  target_include_directories(${PROJECT_NAME}_test_support PUBLIC test/include)
-
-  # The actual tests...
-  catkin_add_gtest(${PROJECT_NAME}_conversion_tests test/conversion_utest.cpp)
-  target_link_libraries(${PROJECT_NAME}_conversion_tests ${PROJECT_NAME}_test_support)
-
-  catkin_add_gtest(${PROJECT_NAME}_extrinsic_multi_static_camera_tests test/extrinsic_multi_static_camera_utest.cpp)
-  target_link_libraries(${PROJECT_NAME}_extrinsic_multi_static_camera_tests ${PROJECT_NAME}_test_support)
-
-  catkin_add_gtest(${PROJECT_NAME}_extrinsic_camera_on_wrist_tests test/extrinsic_camera_on_wrist_utest.cpp)
-  target_link_libraries(${PROJECT_NAME}_extrinsic_camera_on_wrist_tests ${PROJECT_NAME}_test_support)
+if(RCT_BUILD_TESTS)
+  enable_testing()
+  rct_add_run_tests_target()
+  add_subdirectory(test)
 endif()
 
-#############
-## Install ##
-#############
+rct_configure_package(${PROJECT_NAME})
 
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
+install(DIRECTORY include/${PROJECT_NAME}
+  DESTINATION include
 )

--- a/rct_optimizations/cmake/rct_optimizations-config.cmake.in
+++ b/rct_optimizations/cmake/rct_optimizations-config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+set(@PROJECT_NAME@_FOUND ON)
+set_and_check(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
+
+include(CMakeFindDependencyMacro)
+find_dependency(Ceres)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/rct_optimizations/package.xml
+++ b/rct_optimizations/package.xml
@@ -16,6 +16,10 @@
 
   <license>Apache 2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
   <depend>libceres-dev</depend>
+  <depend>rct_common</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 </package>

--- a/rct_optimizations/test/CMakeLists.txt
+++ b/rct_optimizations/test/CMakeLists.txt
@@ -1,0 +1,37 @@
+find_package(GTest REQUIRED)
+
+# Build the test support library
+add_library(${PROJECT_NAME}_test_support
+  src/pose_generator.cpp
+  src/observation_creator.cpp
+  src/utilities.cpp)
+target_link_libraries(${PROJECT_NAME}_test_support ${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME}_test_support PUBLIC include)
+
+# The actual tests...
+add_executable(${PROJECT_NAME}_conversion_tests conversion_utest.cpp)
+target_link_libraries(${PROJECT_NAME}_conversion_tests PRIVATE ${PROJECT_NAME}_test_support GTest::GTest GTest::Main)
+rct_gtest_discover_tests(${PROJECT_NAME}_conversion_tests)
+add_dependencies(${PROJECT_NAME}_conversion_tests ${PROJECT_NAME})
+add_dependencies(run_tests ${PROJECT_NAME}_conversion_tests)
+
+add_executable(${PROJECT_NAME}_extrinsic_multi_static_camera_tests extrinsic_multi_static_camera_utest.cpp)
+target_link_libraries(${PROJECT_NAME}_extrinsic_multi_static_camera_tests PRIVATE ${PROJECT_NAME}_test_support GTest::GTest GTest::Main)
+rct_gtest_discover_tests(${PROJECT_NAME}_extrinsic_multi_static_camera_tests)
+add_dependencies(${PROJECT_NAME}_extrinsic_multi_static_camera_tests ${PROJECT_NAME})
+add_dependencies(run_tests ${PROJECT_NAME}_extrinsic_multi_static_camera_tests)
+
+add_executable(${PROJECT_NAME}_extrinsic_camera_on_wrist_tests extrinsic_camera_on_wrist_utest.cpp)
+target_link_libraries(${PROJECT_NAME}_extrinsic_camera_on_wrist_tests PRIVATE ${PROJECT_NAME}_test_support GTest::GTest GTest::Main)
+rct_gtest_discover_tests(${PROJECT_NAME}_extrinsic_camera_on_wrist_tests)
+add_dependencies(${PROJECT_NAME}_extrinsic_camera_on_wrist_tests ${PROJECT_NAME})
+add_dependencies(run_tests ${PROJECT_NAME}_extrinsic_camera_on_wrist_tests)
+
+# Install the test executables so they can be run independently later if needed
+install(TARGETS
+          ${PROJECT_NAME}_conversion_tests
+          ${PROJECT_NAME}_extrinsic_multi_static_camera_tests
+          ${PROJECT_NAME}_extrinsic_camera_on_wrist_tests
+        RUNTIME DESTINATION bin/tests
+        LIBRARY DESTINATION lib/tests
+        ARCHIVE DESTINATION lib/tests)

--- a/rct_ros_tools/CMakeLists.txt
+++ b/rct_ros_tools/CMakeLists.txt
@@ -1,11 +1,12 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.0)
 project(rct_ros_tools)
 
 add_compile_options(-std=c++11 -Wall -Wextra)
 
+find_package(rct_optimizations REQUIRED)
+
 find_package(catkin REQUIRED COMPONENTS
   rct_image_tools
-  rct_optimizations
   roscpp
 
   # TODO: Export these to a different package dedicated to 'ros tools'
@@ -26,6 +27,7 @@ catkin_package(
     yaml-cpp
   CATKIN_DEPENDS
     roscpp
+    rct_image_tools
 )
 
 ###########
@@ -48,6 +50,7 @@ add_dependencies(${PROJECT_NAME}_data_loader ${${PROJECT_NAME}_EXPORTED_TARGETS}
 target_link_libraries(${PROJECT_NAME}_data_loader
  yaml-cpp
  ${OpenCV_LIBRARIES}
+ rct::rct_optimizations
 )
 
 # Executable for collecting data sets via subscribers and triggered with services


### PR DESCRIPTION
The first step at enabling #35. The work I had done previously converted the RCT packages to be ROS2 packages via Ament, which isn't an ideal strategy for us to use here, so this is a fresh take on the task.

- Remove Catkin dependencies, macros, and functions from `rct_optimizations`.
- Change minimum required CMake version from 2.8.3 to 3.5.0.
- Add a set of CMake macros (in `rct_optimizations/cmake/rct_macros.cmake`) to streamline package configuration and test setup. The idea is that the other RCT packages will be able to use these too. These macros are lightly modified from the ones used in [Tesseract](https://github.com/ros-industrial-consortium/tesseract/blob/master/tesseract/tesseract_common/cmake/tesseract_macros.cmake).
- Use a more "modern CMake" approach in `rct_optimizations/CMakeLists.txt`. It now provides its libraries through the `rct::rct_optimizations` target.
- Move test source code to a `test` directory, which is added as a subdirectory if the `RCT_ENABLE_RUN_TESTING` flag is `True`.
- Change how `rct_image_tools`, `rct_ros_tools`, and `rct_examples` find and link against `rct_optimizations` to accommodate the fact that it is no longer a ROS package.

TODOs:

- [x] Questions for @marip8: Do the changes I made to the way tests are structured still allow CI to build and run tests? Do we have to add `RCT_ENABLE_RUN_TESTING` to `.github_actions.yml`?