### PR TITLE
Pose Generation Update

### DIFF
--- a/rct_optimizations/test/include/rct_optimizations_tests/observation_creator.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/observation_creator.h
@@ -2,6 +2,7 @@
 #define RCT_OPTIMIZATIONS_TESTS_OBS_CREATOR_H
 
 #include <rct_optimizations_tests/utilities.h>
+#include <rct_optimizations_tests/pose_generator.h>
 
 namespace rct_optimizations
 {
@@ -38,14 +39,38 @@ Correspondence3D3D::Set getCorrespondences(const Eigen::Isometry3d &camera_pose,
                                            const Target &target) noexcept;
 
 /**
- * @brief Defines a camera matrix using a camera origin, a position its looking at, and an up vector hint
- * @param origin - The position of the camera focal point
- * @param eye - A point that the camera is looking at
- * @param up - The upvector in world-space
+ * @brief Creates a 2D-3D observation set
+ * @param camera - camera intrinsics
+ * @param target - target definition
+ * @param pose_generator - base class for camera pose generation
+ * @param true_target_mount_to_target - the true transform from the target mount to the target
+ * @param true_camera_mount_to_camera - the true transform from the camera mount to the camera
+ * @param camera_base_to_target_base - the transform from the camera base frame to the target base frame (typically identity)
+ * @return
  */
-Eigen::Isometry3d lookAt(const Eigen::Vector3d &origin,
-                         const Eigen::Vector3d &eye,
-                         const Eigen::Vector3d &up) noexcept;
+Observation2D3D::Set createObservations(
+  const Camera &camera,
+  const Target &target,
+  const PoseGenerator &pose_generator,
+  const Eigen::Isometry3d &true_target_mount_to_target,
+  const Eigen::Isometry3d &true_camera_mount_to_camera,
+  const Eigen::Isometry3d &camera_base_to_target_base = Eigen::Isometry3d::Identity());
+
+/**
+ * @brief Creates a 3D-3D observation set
+ * @param target - target definition
+ * @param pose_generator - base class for camera pose generation
+ * @param true_target_mount_to_target - the true transform from the target mount to the target
+ * @param true_camera_mount_to_camera - the true transform from the camera mount to the camera
+ * @param camera_base_to_target_base - the transform from the camera base frame to the target base frame (typically identity)
+ * @return
+ */
+Observation3D3D::Set createObservations(
+  const Target &target,
+  const PoseGenerator &pose_generator,
+  const Eigen::Isometry3d &true_target_mount_to_target,
+  const Eigen::Isometry3d &true_camera_mount_to_camera,
+  const Eigen::Isometry3d &camera_base_to_target_base = Eigen::Isometry3d::Identity());
 
 } // namespace test
 } // namespace rct_optimizations

--- a/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "rct_optimizations_tests/observation_creator.h"
-#include <rct_optimizations_tests/utilities.h>
 #include <Eigen/Geometry>
 #include <vector>
 
@@ -9,33 +7,89 @@ namespace rct_optimizations
 {
 namespace test
 {
-/**
- * @brief genHemispherePose Generates camera poses in a hemisphere pattern
- * @param target_pose The position of the target
- * @param r Radius of the hemisphere
- * @param theta_cnt The number of points in the theta-wise direction
- * @param phi_cnt The number of points in the phi-wise direction
- * @return A vector of camera positions & orientations
- */
-std::vector<Eigen::Isometry3d> genHemispherePose(const Eigen::Vector3d& target_pose, const double r, const unsigned int theta_cnt, const unsigned int phi_cnt);
-/**
- * @brief genConicalPose Generates camera positions using a conical template, with the target at the 'point'
- * @param target_pose The position of the target
- * @param r Radius of the cone
- * @param h Height of the cone (distance to target)
- * @param theta_cnt Number of observations in a theta direction
- * @return A vector of camera positions & orientations
- */
-std::vector<Eigen::Isometry3d> genConicalPose(const Eigen::Vector3d& target_pose, const unsigned int observations, const double r, const double h);
 
 /**
- * @brief genGridPose Generates camera positions in a grid pattern
- * @param target_pose The position of the target
- * @param grid_side number of columns & rows to go into grid
- * @param spacing Distance betweeon points
- * @param h Grid distance to target
- * @return A vector of camera positions & orientations
+ * @brief Defines a camera matrix using a camera origin, a position its looking at, and an up vector hint
+ * @param origin - The position of the camera focal point
+ * @param eye - A point that the camera is looking at
+ * @param up - The upvector in world-space
  */
-std::vector<Eigen::Isometry3d> genGridPose(const Eigen::Vector3d& target_pose, const unsigned int grid_side, const double spacing, const double h);
+Eigen::Isometry3d lookAt(const Eigen::Vector3d &origin,
+                         const Eigen::Vector3d &eye,
+                         const Eigen::Vector3d &up) noexcept;
+
+struct PoseGenerator
+{
+  /**
+   * @brief Generates a set of camera poses
+   * @param target_origin The position of the target
+   * @return A vector of camera positions & orientations
+   */
+  virtual std::vector<Eigen::Isometry3d> generate(const Eigen::Vector3d &target_origin) const = 0;
+};
+
+/**
+ * @brief Generates camera poses in a hemisphere pattern
+ */
+struct HemispherePoseGenerator : PoseGenerator
+{
+  inline HemispherePoseGenerator(double r_ = 2.0,
+                                 unsigned theta_cnt_ = 10,
+                                 unsigned phi_cnt_ = 10)
+    : r(r_)
+    , theta_cnt(theta_cnt_)
+    , phi_cnt(phi_cnt_)
+  {
+  }
+
+  virtual std::vector<Eigen::Isometry3d> generate(
+    const Eigen::Vector3d &target_origin) const override final;
+
+  double r; /* @brief Radius of the hemisphere */
+  unsigned theta_cnt; /* @brief The number of points in the theta-wise direction*/
+  unsigned phi_cnt; /* @brief The number of points in the phi-wise direction */
+};
+
+/**
+ * @brief Generates camera positions using a conical template, with the target at the 'point'
+ */
+struct ConicalPoseGenerator : PoseGenerator
+{
+  inline ConicalPoseGenerator(double r_ = 1.0,
+                              double h_ = 2.0,
+                              unsigned n_poses_ = 20)
+    : r(r_)
+    , h(h_)
+    , n_poses(n_poses_)
+  {
+  }
+
+  virtual std::vector<Eigen::Isometry3d> generate(
+    const Eigen::Vector3d &target_origin) const override final;
+
+  double r; /** @brief Radius of the cone*/
+  double h; /** @brief Height of the cone (distance to target) */
+  unsigned n_poses; /** @brief Number of poses to generate */
+};
+
+struct GridPoseGenerator : PoseGenerator
+{
+  inline GridPoseGenerator(double spacing_ = 0.2,
+                           double h_ = 2.0,
+                           unsigned grid_side_ = 10)
+    : spacing(spacing_)
+    , h(h_)
+    , grid_side(grid_side_)
+  {
+  }
+
+  virtual std::vector<Eigen::Isometry3d> generate(
+    const Eigen::Vector3d &target_origin) const override final;
+
+  double spacing; /** @brief Distance betweeon points */
+  double h; /** @brief Grid distance to target */
+  unsigned grid_side; /** number of columns & rows to go into grid */
+};
+
 }  // namespace test
 }  // namespace rct_optimizations


### PR DESCRIPTION
This PR adds functions for generating observation sets using the pose generators from #43. In order to make the pose generators easier to use with the observation generators, their structure was refactored into and interface with implementations.

The hand-eye unit tests currently only use one of the pose generators. We probably want to devise a way of testing all of the pose generators with the optimizations. I am still trying to figure out a clean way to do this but haven't come across a good solution yet.

Builds on #48 