### PR TITLE
Replace instances of deprecated CorrespondenceSet with Correspondence2D3D::Set

### DIFF
--- a/rct_examples/src/tools/intrinsic_calibration.cpp
+++ b/rct_examples/src/tools/intrinsic_calibration.cpp
@@ -11,7 +11,7 @@
 
 #include <opencv2/calib3d.hpp>
 
-void opencvCameraCalibration(const std::vector<rct_optimizations::CorrespondenceSet>& obs,
+void opencvCameraCalibration(const std::vector<rct_optimizations::Correspondence2D3D::Set>& obs,
                              const cv::Size& image_size,
                              const rct_optimizations::CameraIntrinsics& intr)
 {

--- a/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
@@ -21,7 +21,7 @@ static void reproject(const Eigen::Isometry3d& base_to_target,
                       const std::vector<rct_optimizations::CameraIntrinsics>& intr,
                       const rct_image_tools::ModifiedCircleGridTarget& target,
                       const cv::Mat& image,
-                      const std::vector<rct_optimizations::CorrespondenceSet>& corr)
+                      const std::vector<rct_optimizations::Correspondence2D3D::Set>& corr)
 {
 
   Eigen::Isometry3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
@@ -195,7 +195,7 @@ int main(int argc, char** argv)
 
   for (std::size_t i = 0; i < maybe_data_set[0].images.size(); ++i)
   {
-    std::vector<rct_optimizations::CorrespondenceSet> corr_set;
+    std::vector<rct_optimizations::Correspondence2D3D::Set> corr_set;
     std::vector<Eigen::Isometry3d> base_to_camera;
     Eigen::Isometry3d base_to_wrist;
     std::vector<rct_optimizations::CameraIntrinsics> intr;

--- a/rct_examples/src/tools/multi_static_camera_multi_step_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_multi_step_extrinsic.cpp
@@ -21,7 +21,7 @@ static void reproject(const Eigen::Isometry3d& base_to_target,
                       const std::vector<rct_optimizations::CameraIntrinsics>& intr,
                       const rct_image_tools::ModifiedCircleGridTarget& target,
                       const cv::Mat& image,
-                      const std::vector<rct_optimizations::CorrespondenceSet>& corr)
+                      const std::vector<rct_optimizations::Correspondence2D3D::Set>& corr)
 {
 
   Eigen::Isometry3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
@@ -230,7 +230,7 @@ int main(int argc, char** argv)
 
   for (std::size_t i = 0; i < problem_wrist_def.wrist_poses.size(); ++i)
   {
-    std::vector<rct_optimizations::CorrespondenceSet> corr_set;
+    std::vector<rct_optimizations::Correspondence2D3D::Set> corr_set;
     std::vector<Eigen::Isometry3d> base_to_camera;
     Eigen::Isometry3d base_to_target;
     std::vector<rct_optimizations::CameraIntrinsics> intr;

--- a/rct_examples/src/tools/solve_multi_camera_pnp.cpp
+++ b/rct_examples/src/tools/solve_multi_camera_pnp.cpp
@@ -22,7 +22,7 @@ static void reproject(const Eigen::Isometry3d& base_to_target,
                       const std::vector<rct_optimizations::CameraIntrinsics>& intr,
                       const rct_image_tools::ModifiedCircleGridTarget& target,
                       const cv::Mat& image,
-                      const std::vector<rct_optimizations::CorrespondenceSet>& corr)
+                      const std::vector<rct_optimizations::Correspondence2D3D::Set>& corr)
 {
 
   Eigen::Isometry3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
@@ -150,7 +150,7 @@ int main(int argc, char** argv)
   {
     if (corr_data_set.getImageCameraCount(i) == corr_data_set.getCameraCount())
     {
-      std::vector<rct_optimizations::CorrespondenceSet> corr_set;
+      std::vector<rct_optimizations::Correspondence2D3D::Set> corr_set;
       for (std::size_t c = 0; c < num_of_cameras; ++c)
       {
         corr_set.push_back(corr_data_set.getCorrespondenceSet(c, i));

--- a/rct_image_tools/include/rct_image_tools/image_utils.h
+++ b/rct_image_tools/include/rct_image_tools/image_utils.h
@@ -60,9 +60,9 @@ void drawReprojections(const std::vector<cv::Point2d> &reprojections,
  * @return The correspondence set
  */
 inline
-rct_optimizations::CorrespondenceSet getCorrespondenceSet(const std::vector<Eigen::Vector2d> &observations, const std::vector<Eigen::Vector3d> &target_points)
+rct_optimizations::Correspondence2D3D::Set getCorrespondenceSet(const std::vector<Eigen::Vector2d> &observations, const std::vector<Eigen::Vector3d> &target_points)
 {
-  rct_optimizations::CorrespondenceSet obs_set;
+  rct_optimizations::Correspondence2D3D::Set obs_set;
 
   //// Create the correspondence pairs
   assert(observations.size() == target_points.size());
@@ -87,12 +87,12 @@ rct_optimizations::CorrespondenceSet getCorrespondenceSet(const std::vector<Eige
  * @return A correspondence set
  */
 inline
-rct_optimizations::CorrespondenceSet getCorrespondenceSet(const rct_image_tools::ModifiedCircleGridObservationFinder &obs_finder, const cv::Mat& image)
+rct_optimizations::Correspondence2D3D::Set getCorrespondenceSet(const rct_image_tools::ModifiedCircleGridObservationFinder &obs_finder, const cv::Mat& image)
 {
   const rct_image_tools::ModifiedCircleGridTarget& target = obs_finder.target();
   auto maybe_obs = obs_finder.findObservations(image);
 
-  rct_optimizations::CorrespondenceSet obs_set;
+  rct_optimizations::Correspondence2D3D::Set obs_set;
   if (maybe_obs)
   {
     obs_set = getCorrespondenceSet(*maybe_obs, target.points);

--- a/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
+++ b/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
@@ -9,7 +9,7 @@ namespace rct_optimizations
 
 struct IntrinsicEstimationProblem
 {
-  std::vector<CorrespondenceSet> image_observations;
+  std::vector<Correspondence2D3D::Set> image_observations;
   CameraIntrinsics intrinsics_guess;
 
   bool use_extrinsic_guesses;

--- a/rct_optimizations/include/rct_optimizations/experimental/multi_camera_pnp.h
+++ b/rct_optimizations/include/rct_optimizations/experimental/multi_camera_pnp.h
@@ -32,7 +32,7 @@ struct MultiCameraPnPProblem
    * Each observation set consists of a set of correspodences: a 3D position (e.g. a dot) in "target
    * frame" to the image location it was detected at (2D). The outer-most vector is for each camera,
    * the inner vector is the images valid for that camera. */
-  std::vector<CorrespondenceSet> image_observations;
+  std::vector<Correspondence2D3D::Set> image_observations;
 
   /** @brief Your best guess for transforms, "base to target", for a given observation set taken.*/
   Eigen::Isometry3d base_to_target_guess;

--- a/rct_optimizations/include/rct_optimizations/experimental/pnp.h
+++ b/rct_optimizations/include/rct_optimizations/experimental/pnp.h
@@ -9,7 +9,7 @@ namespace rct_optimizations
 struct PnPProblem
 {
   rct_optimizations::CameraIntrinsics intr;
-  CorrespondenceSet correspondences;
+  Correspondence2D3D::Set correspondences;
 
   Eigen::Isometry3d camera_to_target_guess;
 };

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera.h
@@ -39,7 +39,7 @@ struct ExtrinsicMultiStaticCameraMovingTargetProblem
    * frame" to the image location it was detected at (2D). The outer-most vector is for each camera,
    * the inner vector is the images valid for that camera.
    */
-  std::vector<std::vector<CorrespondenceSet>> image_observations;
+  std::vector<std::vector<Correspondence2D3D::Set>> image_observations;
 
   /** @brief Your best guess at the "wrist frame" to "target frame" transform */
   Eigen::Isometry3d wrist_to_target_guess;

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_only.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_only.h
@@ -44,7 +44,7 @@ struct ExtrinsicMultiStaticCameraOnlyProblem
    * frame" to the image location it was detected at (2D). The outer-most vector is for each camera,
    * the inner vector is the images valid for that camera.
    */
-  std::vector<std::vector<CorrespondenceSet>> image_observations;
+  std::vector<std::vector<Correspondence2D3D::Set>> image_observations;
 
   /** @brief Your best guess at the "base frame" to "camera frame" transform; one for each camera */
   std::vector<Eigen::Isometry3d> base_to_camera_guess;

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_wrist_only.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_wrist_only.h
@@ -39,7 +39,7 @@ struct ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem
    * frame" to the image location it was detected at (2D). The outer-most vector is for each camera,
    * the inner vector is the images valid for that camera.
    */
-  std::vector<std::vector<CorrespondenceSet>> image_observations;
+  std::vector<std::vector<Correspondence2D3D::Set>> image_observations;
 
   /** @brief Your best guess at the "wrist frame" to "target frame" transform */
   Eigen::Isometry3d wrist_to_target_guess;

--- a/rct_optimizations/src/rct_optimizations/camera_intrinsic.cpp
+++ b/rct_optimizations/src/rct_optimizations/camera_intrinsic.cpp
@@ -113,7 +113,7 @@ void projectPoints2(const T* const camera_intr, const T* const pt_in_camera, T* 
 }
 
 static rct_optimizations::Pose6d solvePnP(const rct_optimizations::CameraIntrinsics& intr,
-                                          const rct_optimizations::CorrespondenceSet& obs,
+                                          const rct_optimizations::Correspondence2D3D::Set& obs,
                                           const rct_optimizations::Pose6d& guess)
 {
   using namespace rct_optimizations;

--- a/rct_optimizations/test/extrinsic_multi_static_camera_utest.cpp
+++ b/rct_optimizations/test/extrinsic_multi_static_camera_utest.cpp
@@ -37,7 +37,7 @@ void printResults(const ExtrinsicMultiStaticCameraMovingTargetResult &opt_result
 struct Observations
 {
   std::vector<Eigen::Isometry3d> wrist_poses;
-  std::vector<CorrespondenceSet> correspondences;
+  std::vector<Correspondence2D3D::Set> correspondences;
 };
 
 Observations addObservations(const test::Target &target,
@@ -65,11 +65,11 @@ Observations addObservations(const test::Target &target,
     Eigen::Isometry3d base_to_target = base_to_wrist * wrist_to_target;
 
     // Get visible observations
-    CorrespondenceSet obs_set = test::getCorrespondences(base_to_camera,
-                                                         base_to_target,
-                                                         camera,
-                                                         target,
-                                                         false);
+    Correspondence2D3D::Set obs_set = test::getCorrespondences(base_to_camera,
+                                                               base_to_target,
+                                                               camera,
+                                                               target,
+                                                               false);
 
     if (obs_set.size() > 0)
     {

--- a/rct_ros_tools/include/rct_ros_tools/data_set.h
+++ b/rct_ros_tools/include/rct_ros_tools/data_set.h
@@ -47,11 +47,11 @@ public:
   bool foundCorrespondence(std::size_t camera_index, std::size_t image_index) const;
 
   /** @brief Get the correspondence set for a given camera and image index */
-  const rct_optimizations::CorrespondenceSet& getCorrespondenceSet(std::size_t camera_index, std::size_t image_index) const;
+  const rct_optimizations::Correspondence2D3D::Set& getCorrespondenceSet(std::size_t camera_index, std::size_t image_index) const;
 
 private:
   /** @brief Correspondence pairs for a given image and camera */
-  Eigen::Matrix<rct_optimizations::CorrespondenceSet, Eigen::Dynamic, Eigen::Dynamic> correspondences_;
+  Eigen::Matrix<rct_optimizations::Correspondence2D3D::Set, Eigen::Dynamic, Eigen::Dynamic> correspondences_;
 
   /** @brief Mask matrix indicating if the target was found */
   Eigen::Matrix<unsigned, Eigen::Dynamic, Eigen::Dynamic> mask_;

--- a/rct_ros_tools/src/data_loader/data_set.cpp
+++ b/rct_ros_tools/src/data_loader/data_set.cpp
@@ -143,7 +143,7 @@ rct_ros_tools::ExtrinsicCorrespondenceDataSet::ExtrinsicCorrespondenceDataSet(co
     {
       mask_(c, i) = 1;
       // Try to find the circle grid in this image:
-      rct_optimizations::CorrespondenceSet obs_set = rct_image_tools::getCorrespondenceSet(obs_finder, data_set.images[i]);
+      rct_optimizations::Correspondence2D3D::Set obs_set = rct_image_tools::getCorrespondenceSet(obs_finder, data_set.images[i]);
       if (obs_set.empty())
       {
         ROS_WARN_STREAM("Unable to find the circle grid in image: " << i);
@@ -191,7 +191,7 @@ bool rct_ros_tools::ExtrinsicCorrespondenceDataSet::foundCorrespondence(std::siz
   return static_cast<bool>(mask_(camera_index, image_index));
 }
 
-const rct_optimizations::CorrespondenceSet&
+const rct_optimizations::Correspondence2D3D::Set&
 rct_ros_tools::ExtrinsicCorrespondenceDataSet::getCorrespondenceSet(std::size_t camera_index, std::size_t image_index) const
 {
   return correspondences_(camera_index, image_index);


### PR DESCRIPTION
I think the deprecated tag on `CorrespondenceSet` was causing issues with CI so I went through and updated uses to the non-deprecated replacement.