### PR TITLE
Camera intrinsic calibration validation

### DIFF
--- a/rct_examples/CMakeLists.txt
+++ b/rct_examples/CMakeLists.txt
@@ -121,7 +121,7 @@ set_target_properties(${PROJECT_NAME}_camera_intrinsic_calibration_validation PR
 
 add_dependencies(${PROJECT_NAME}_camera_intrinsic_calibration_validation ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(${PROJECT_NAME}_camera_intrinsic_calibration_validation ${catkin_LIBRARIES} rct::rct_optimizations)
+target_link_libraries(${PROJECT_NAME}_camera_intrinsic_calibration_validation ${catkin_LIBRARIES} rct::rct_optimizations rct::rct_image_tools)
 
 
 #############

--- a/rct_examples/CMakeLists.txt
+++ b/rct_examples/CMakeLists.txt
@@ -114,6 +114,16 @@ add_dependencies(${PROJECT_NAME}_multi_camera_pnp ${${PROJECT_NAME}_EXPORTED_TAR
 
 target_link_libraries(${PROJECT_NAME}_multi_camera_pnp ${catkin_LIBRARIES} rct::rct_optimizations rct::rct_image_tools)
 
+# Executable demonstrating camera intrinsic calibration validation
+add_executable(${PROJECT_NAME}_camera_intrinsic_calibration_validation src/tools/camera_intrinsic_calibration_validation.cpp)
+
+set_target_properties(${PROJECT_NAME}_camera_intrinsic_calibration_validation PROPERTIES OUTPUT_NAME camera_intrinsic_calibration_validation PREFIX "")
+
+add_dependencies(${PROJECT_NAME}_camera_intrinsic_calibration_validation ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(${PROJECT_NAME}_camera_intrinsic_calibration_validation ${catkin_LIBRARIES} rct::rct_optimizations)
+
+
 #############
 ## Testing ##
 #############
@@ -134,6 +144,7 @@ install(TARGETS
     ${PROJECT_NAME}_multi_static_camera
     ${PROJECT_NAME}_intr
     ${PROJECT_NAME}_pnp
+    ${PROJECT_NAME}_camera_intrinsic_calibration_validation
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/rct_examples/launch/camera_intrinsic_calibration_validation.launch
+++ b/rct_examples/launch/camera_intrinsic_calibration_validation.launch
@@ -1,0 +1,13 @@
+<launch>
+  <arg name="camera_file" default="$(find rct_examples)/config/kinect_camera_intr.yaml"/>
+  <arg name="target_file" default="$(find rct_examples)/config/target_10x10.yaml"/>
+  <arg name="guess_file" default="$(find rct_examples)/config/camera_on_wrist_guesses.yaml"/>
+  <arg name="data_path" default="$(find rct_examples)/data/test_set_10x10/cal_data.yaml"/>
+
+  <node pkg="rct_examples" type="camera_intrinsic_calibration_validation" name="camera_intr_validation" output="screen">
+    <rosparam command="load" file="$(arg camera_file)"/>
+    <rosparam command="load" file="$(arg target_file)"/>
+    <rosparam command="load" file="$(arg guess_file)"/>
+    <param name="data_path" value="$(arg data_path)"/>
+  </node>
+</launch>

--- a/rct_examples/src/tools/camera_intrinsic_calibration_validation.cpp
+++ b/rct_examples/src/tools/camera_intrinsic_calibration_validation.cpp
@@ -16,7 +16,7 @@ void analyzeResults(const rct_optimizations::IntrinsicCalibrationAccuracyResult 
                     const double pos_tol, const double ang_tol)
 {
   ROS_INFO_STREAM("Positional Error:\nMean (m): " << result.pos_error.first << "\nStd. Dev. (m): " << result.pos_error.second);
-  ROS_INFO_STREAM("Angular Error:\nMean (m): " << result.ang_error.first << "\nStd. Dev. (m): " << result.ang_error.second);
+  ROS_INFO_STREAM("Angular Error:\nMean (rad): " << result.ang_error.first << "\nStd. Dev. (rad): " << result.ang_error.second);
 
   // Calculate the error such that it represents ~95% of the results (mean + 2 * sigma)
   double pos_error = result.pos_error.first + 2.0 * result.pos_error.second;

--- a/rct_examples/src/tools/camera_intrinsic_calibration_validation.cpp
+++ b/rct_examples/src/tools/camera_intrinsic_calibration_validation.cpp
@@ -1,0 +1,134 @@
+#include <rct_optimizations/validation/camera_intrinsic_calibration_validation.h>
+#include <rct_ros_tools/parameter_loaders.h>
+#include <rct_ros_tools/print_utils.h>
+#include <rct_ros_tools/data_set.h>
+
+// To find 2D  observations from images
+#include <rct_image_tools/image_observation_finder.h>
+#include <rct_image_tools/image_utils.h>
+
+// For display of found targets
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+#include <ros/ros.h>
+
+void analyzeResults(const rct_optimizations::IntrinsicCalibrationAccuracyResult &result,
+                    const double pos_tol, const double ang_tol)
+{
+  ROS_INFO_STREAM("Positional Error:\nMean (m): " << result.pos_error.first << "\nStd. Dev. (m): " << result.pos_error.second);
+  ROS_INFO_STREAM("Angular Error:\nMean (m): " << result.ang_error.first << "\nStd. Dev. (m): " << result.ang_error.second);
+
+  // Calculate the error such that it represents ~95% of the results (mean + 2 * sigma)
+  double pos_error = result.pos_error.first + 2.0 * result.pos_error.second;
+  double ang_error = result.ang_error.first + 2.0 * result.ang_error.second;
+  if (pos_error > pos_tol || ang_error > ang_tol)
+  {
+    ROS_WARN_STREAM("Camera intrinsic calibration is not within tolerance\nPosition Error (m): "
+                    << pos_error << " (" << pos_tol << " allowed)"
+                    << "\nAngular Error (rad): " << ang_error << " (" << ang_tol << " allowed)");
+  }
+  else
+  {
+    ROS_INFO_STREAM("Camera intrinsic calibration is valid!");
+  }
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "camera_on_wrist_extrinsic");
+  ros::NodeHandle pnh("~");
+
+  // Load the data set path from ROS param
+  std::string data_path;
+  if (!pnh.getParam("data_path", data_path))
+  {
+    ROS_ERROR("Must set 'data_path' parameter");
+    return 1;
+  }
+
+  try
+  {
+    rct_image_tools::ModifiedCircleGridTarget target = rct_ros_tools::loadTarget(pnh, "target_definition");
+    rct_optimizations::CameraIntrinsics intr = rct_ros_tools::loadIntrinsics(pnh, "intrinsics");
+
+    // Attempt to load the data set via the data record yaml file:
+    boost::optional<rct_ros_tools::ExtrinsicDataSet> maybe_data_set = rct_ros_tools::parseFromFile(
+      data_path);
+    if (!maybe_data_set)
+    {
+      ROS_ERROR_STREAM("Failed to parse data set from path = " << data_path);
+      return 2;
+    }
+
+    // We know it exists, so define a helpful alias
+    const rct_ros_tools::ExtrinsicDataSet& data_set = *maybe_data_set;
+
+    // Our 'base to camera guess': A camera off to the side, looking at a point centered in front of the robot
+    Eigen::Isometry3d target_mount_to_target = rct_ros_tools::loadPose(pnh, "base_to_target_guess");
+    Eigen::Isometry3d camera_mount_to_camera = rct_ros_tools::loadPose(pnh, "wrist_to_camera_guess");
+
+    // Lets create a class that will search for the target in our raw images.
+    rct_image_tools::ModifiedCircleGridObservationFinder obs_finder(target);
+
+    // Finally, we need to process our images into correspondence sets: for each dot in the
+    // target this will be where that dot is in the target and where it was seen in the image.
+    // Repeat for each image. We also tell where the wrist was when the image was taken.
+    rct_optimizations::Observation2D3D::Set observations;
+    observations.reserve(data_set.images.size());
+    for (std::size_t i = 0; i < data_set.images.size(); ++i)
+    {
+      // Try to find the circle grid in this image:
+      auto maybe_obs = obs_finder.findObservations(data_set.images[i]);
+      if (!maybe_obs)
+      {
+        ROS_WARN_STREAM("Unable to find the circle grid in image: " << i);
+        cv::imshow("points", data_set.images[i]);
+        cv::waitKey();
+        continue;
+      }
+      else
+      {
+        // Show the points we detected
+        cv::imshow("points", obs_finder.drawObservations(data_set.images[i], *maybe_obs));
+        cv::waitKey();
+      }
+
+      rct_optimizations::Observation2D3D obs;
+      obs.correspondence_set.reserve(maybe_obs->size());
+
+      // So for each image we need to:
+      //// 1. Record the wrist position
+      obs.to_camera_mount = data_set.tool_poses[i];
+      obs.to_target_mount = Eigen::Isometry3d::Identity();
+
+      //// And finally add that to the problem
+      obs.correspondence_set = rct_image_tools::getCorrespondenceSet(*maybe_obs, target.points);
+
+      observations.push_back(obs);
+    }
+
+    // Measure the intrinsic calibration accuracy
+    // The assumption here is that all PnP optimizations should have a residual error less than 1.0 pixels
+    rct_optimizations::IntrinsicCalibrationAccuracyResult result
+      = rct_optimizations::measureIntrinsicCalibrationAccuracy(observations,
+                                                               intr,
+                                                               camera_mount_to_camera,
+                                                               target_mount_to_target,
+                                                               Eigen::Isometry3d::Identity(),
+                                                               1.0);
+
+    // Analyze the results
+    // These error tolerances allow the virtual correspondence sets for each observation to deviate from the expectation by up to 1 mm and 0.05 degrees
+    // The chosen tolerances are relatively arbitrary, but should be very small
+    double pos_tol = 1.0e-3;
+    double ang_tol = 0.05 * M_PI / 180.0;
+    analyzeResults(result, pos_tol, ang_tol);
+  }
+  catch (const std::exception &ex)
+  {
+    ROS_ERROR_STREAM(ex.what());
+    return -1;
+  }
+
+  return 0;
+}

--- a/rct_optimizations/CMakeLists.txt
+++ b/rct_optimizations/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/multi_camera_pnp.cpp
   # DH Chain
   src/${PROJECT_NAME}/dh_chain.cpp
+  # Validation Tools
+  src/${PROJECT_NAME}/validation/camera_intrinsic_calibration_validation.cpp
 )
 target_compile_options(${PROJECT_NAME} PUBLIC -std=c++14)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)

--- a/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
+++ b/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <rct_optimizations/experimental/pnp.h>
+#include <rct_optimizations/types.h>
+
+namespace rct_optimizations
+{
+/**
+ * @brief Divides a set of correspondences into two halves and calculates the transform from one half to the other
+ *   Method:
+ *     1. Split the correspondence set into two virtual correspondence sets
+ *     2. Solve PnP optimization for each virtual correspondence set to get the transform from the camera to the virtual targets
+ *     3. Return the transform between the two virtual targets
+ *
+ *  Note: the two virtual targets are composed of different points, but those points are relative to the same origin
+ *  Therefore, the transformation from one virtual target to the other should be identity, given perfect camera intrinsic parameters
+ *
+ * @param correspondences - set of corresponding observed features and target features
+ * @param intr - camera intrinsic parameters
+ * @param camera_to_target_guess - an initial guess about the location of the target relative to the camera (default: identity)
+ * @param residual_sq_error_threshold - Max squared error allowed for a PnP optimization (default: 1.0 pixel^2)
+ * @return the transformation from the first virtual target to the second (identity, given perfect camera intrinsic parameters)
+ */
+Eigen::Isometry3d getInternalTargetTransformation(
+  const Correspondence2D3D::Set &correspondences,
+  const CameraIntrinsics &intr,
+  const Eigen::Isometry3d &camera_to_target_guess = Eigen::Isometry3d::Identity(),
+  const double residual_sq_error_threshold = 1.0);
+
+} // namespace rct_optimizations

--- a/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
+++ b/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <rct_optimizations/experimental/pnp.h>
+#include <rct_optimizations/pnp.h>
 #include <rct_optimizations/types.h>
 
 namespace rct_optimizations

--- a/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
+++ b/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
@@ -6,56 +6,78 @@
 namespace rct_optimizations
 {
 /**
- * @brief Divides a set of correspondences into two halves and calculates the transform from one half to the other
+ * @brief Structure containing the error measurements between 2 virtual correspondence sets within one real correspondence set
+ */
+struct VirtualCorrespondenceResult
+{
+  /** @brief Transform from the first virtual correspondence set to the second */
+  Eigen::Isometry3d t1_to_t2;
+  /** @brief The positional error between the transforms from the first and second virtual correspondence sets (m) */
+  double positional_error;
+  /** @brief The angular error between the transforms from the first and second virtual correspondence sets (rad) */
+  double angular_error;
+};
+
+/**
+ * @brief Divides a set of correspondences into two halves and measures the difference in position of one half to the other
  *   Method:
  *     1. Split the correspondence set into two virtual correspondence sets
- *     2. Solve PnP optimization for each virtual correspondence set to get the transform from the camera to the virtual targets
- *     3. Return the transform between the two virtual targets
+ *     2. Solve PnP optimization for each virtual correspondence set to get the transform from the camera to the virtual correspondence set
+ *     3. Return the error between the two virtual correspondence sets
  *
- *  Note: the two virtual targets are composed of different points, but those points are relative to the same origin
- *  Therefore, the transformation from one virtual target to the other should be identity, given perfect camera intrinsic parameters
+ *  Note: the two virtual correspondence sets are composed of different points, but those points are relative to the same origin
+ *  Therefore, the transformation from one virtual correspondence set to the other should be identity, given perfect camera intrinsic parameters
  *
  * @param correspondences - set of corresponding observed features and target features
  * @param intr - camera intrinsic parameters
  * @param camera_to_target_guess - an initial guess about the location of the target relative to the camera (default: identity)
- * @param residual_sq_error_threshold - Max squared error allowed for a PnP optimization.
+ * @param pnp_sq_error_threshold - Max squared error allowed for a PnP optimization.
  * This value should be driven by the accuracy of the sensor providing the observations (default: 1.0 pixel^2)
- * @return the transformation from the first virtual target to the second (identity, given perfect camera intrinsic parameters)
+ * @return
  */
-Eigen::Isometry3d getInternalTargetTransformation(
+VirtualCorrespondenceResult measureVirtualTargetDiff(
   const Correspondence2D3D::Set &correspondences,
   const CameraIntrinsics &intr,
   const Eigen::Isometry3d &camera_to_target_guess = Eigen::Isometry3d::Identity(),
-  const double residual_sq_error_threshold = 1.0);
+  const double pnp_sq_error_threshold = 1.0);
 
 /**
- * @brief Calculates the mean and variance of the transform between two virtual targets (extracted from a single correspondence set)
+ * @brief Structure containing measurements of the intrinsic calibration accuracy
+ */
+struct IntrinsicCalibrationAccuracyResult
+{
+  std::pair<double, double> pos_error; /** @brief mean/stdev pair for positional error */
+  std::pair<double, double> ang_error; /** @brief mean/stdev pair for angular error */
+};
+
+/**
+ * @brief Calculates the mean and variance of the transform between two virtual correspondence sets (extracted from a single correspondence set)
  * for a set of calibration observations
  *   Method:
  *     1. Check that the correspondences in all observations are the same size
  *       - Assumptions:
  *         - Correspondences are ordered in the same way for each observation
  *         - The correspondences in each observation can be divided in half to get the same two sets of features
- *     2. Calculate transform between two virtual targets in correspondences in adjacent observations
- *     3. Calculate the mean and standard deviation of the positional difference in this transform for all observations
+ *     2. Calculate error between two virtual correspondence sets in adjacent observations
+ *     3. Calculate the mean and standard deviation of the positional difference in this error for all observations
  *       - Theoretically, this difference should be zero for a perfectly intrinsically calibrated camera
  *         that perfectly observed the target features
- *     4. Compare the mean and standard deviation of all the measurements with the threshold
  *
  * @param observations - a set of calibration observations
  * @param intr - camera intrinsic parameters
- * @param threshold - The max allowable deviation in world units (i.e. meters)
- * This value should be driven by the accuracy of the sensor providing the observations
  * @param camera_mount_to_camera - The transformation from the camera mount frame to the camera
  * @param target_mount_to_target - The transformation from the target mount frame to the target
  * @param camera_base_to_target_base - the transform from the camera base frame to the target base frame (typically identity)
- * @return True if the camera intrinsic calibration is valid, false otherwise
+ * @param pnp_sq_error_threshold - Max squared error allowed for a PnP optimization.
+ * This value should be driven by the accuracy of the sensor providing the observations (default: 1.0 pixel^2)
+ * @return
  */
-bool validateCameraIntrinsicCalibration(const Observation2D3D::Set &observations,
-                                        const CameraIntrinsics &intr,
-                                        const double threshold,
-                                        const Eigen::Isometry3d &camera_mount_to_camera,
-                                        const Eigen::Isometry3d &target_mount_to_target,
-                                        const Eigen::Isometry3d &camera_base_to_target_base);
+IntrinsicCalibrationAccuracyResult measureIntrinsicCalibrationAccuracy(
+  const Observation2D3D::Set &observations,
+  const CameraIntrinsics &intr,
+  const Eigen::Isometry3d &camera_mount_to_camera,
+  const Eigen::Isometry3d &target_mount_to_target,
+  const Eigen::Isometry3d &camera_base_to_target_base,
+  const double pnp_sq_error_threshold = 1.0);
 
 } // namespace rct_optimizations

--- a/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
+++ b/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
@@ -18,7 +18,8 @@ namespace rct_optimizations
  * @param correspondences - set of corresponding observed features and target features
  * @param intr - camera intrinsic parameters
  * @param camera_to_target_guess - an initial guess about the location of the target relative to the camera (default: identity)
- * @param residual_sq_error_threshold - Max squared error allowed for a PnP optimization (default: 1.0 pixel^2)
+ * @param residual_sq_error_threshold - Max squared error allowed for a PnP optimization.
+ * This value should be driven by the accuracy of the sensor providing the observations (default: 1.0 pixel^2)
  * @return the transformation from the first virtual target to the second (identity, given perfect camera intrinsic parameters)
  */
 Eigen::Isometry3d getInternalTargetTransformation(
@@ -28,28 +29,33 @@ Eigen::Isometry3d getInternalTargetTransformation(
   const double residual_sq_error_threshold = 1.0);
 
 /**
- * @brief
+ * @brief Calculates the mean and variance of the transform between two virtual targets (extracted from a single correspondence set)
+ * for a set of calibration observations
  *   Method:
  *     1. Check that the correspondences in all observations are the same size
  *       - Assumptions:
  *         - Correspondences are ordered in the same way for each observation
  *         - The correspondences in each observation can be divided in half to get the same two sets of features
  *     2. Calculate transform between two virtual targets in correspondences in adjacent observations
- *     3. Calculate the positional difference in this transform for all observations
+ *     3. Calculate the mean and standard deviation of the positional difference in this transform for all observations
  *       - Theoretically, this difference should be zero for a perfectly intrinsically calibrated camera
  *         that perfectly observed the target features
- *     4. Record the mean and standard deviation of
- *     5. Return whether or not the mean of all the measurements was less than the input threshold
+ *     4. Compare the mean and standard deviation of all the measurements with the threshold
  *
- * @param observations
+ * @param observations - a set of calibration observations
  * @param intr - camera intrinsic parameters
- * @param camera_to_target_guess -
- * @param diff_threshold - The max error
- * @return
+ * @param threshold - The max allowable deviation in world units (i.e. meters)
+ * This value should be driven by the accuracy of the sensor providing the observations
+ * @param camera_mount_to_camera - The transformation from the camera mount frame to the camera
+ * @param target_mount_to_target - The transformation from the target mount frame to the target
+ * @param camera_base_to_target_base - the transform from the camera base frame to the target base frame (typically identity)
+ * @return True if the camera intrinsic calibration is valid, false otherwise
  */
 bool validateCameraIntrinsicCalibration(const Observation2D3D::Set &observations,
                                         const CameraIntrinsics &intr,
-                                        const Eigen::Isometry3d &camera_to_target_guess,
-                                        const double diff_threshold);
+                                        const double threshold,
+                                        const Eigen::Isometry3d &camera_mount_to_camera,
+                                        const Eigen::Isometry3d &target_mount_to_target,
+                                        const Eigen::Isometry3d &camera_base_to_target_base);
 
 } // namespace rct_optimizations

--- a/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
+++ b/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
@@ -27,4 +27,29 @@ Eigen::Isometry3d getInternalTargetTransformation(
   const Eigen::Isometry3d &camera_to_target_guess = Eigen::Isometry3d::Identity(),
   const double residual_sq_error_threshold = 1.0);
 
+/**
+ * @brief
+ *   Method:
+ *     1. Check that the correspondences in all observations are the same size
+ *       - Assumptions:
+ *         - Correspondences are ordered in the same way for each observation
+ *         - The correspondences in each observation can be divided in half to get the same two sets of features
+ *     2. Calculate transform between two virtual targets in correspondences in adjacent observations
+ *     3. Calculate the positional difference in this transform for all observations
+ *       - Theoretically, this difference should be zero for a perfectly intrinsically calibrated camera
+ *         that perfectly observed the target features
+ *     4. Record the mean and standard deviation of
+ *     5. Return whether or not the mean of all the measurements was less than the input threshold
+ *
+ * @param observations
+ * @param intr - camera intrinsic parameters
+ * @param camera_to_target_guess -
+ * @param diff_threshold - The max error
+ * @return
+ */
+bool validateCameraIntrinsicCalibration(const Observation2D3D::Set &observations,
+                                        const CameraIntrinsics &intr,
+                                        const Eigen::Isometry3d &camera_to_target_guess,
+                                        const double diff_threshold);
+
 } // namespace rct_optimizations

--- a/rct_optimizations/src/rct_optimizations/validation/camera_intrinsic_calibration_validation.cpp
+++ b/rct_optimizations/src/rct_optimizations/validation/camera_intrinsic_calibration_validation.cpp
@@ -77,7 +77,7 @@ IntrinsicCalibrationAccuracyResult measureIntrinsicCalibrationAccuracy(
     {
       std::stringstream ss;
       ss << "Correspondence sizes do not match between observations " << i << " and " << i + 1;
-      throw std::runtime_error(ss.str());
+      throw OptimizationException(ss.str());
     }
   }
 

--- a/rct_optimizations/src/rct_optimizations/validation/camera_intrinsic_calibration_validation.cpp
+++ b/rct_optimizations/src/rct_optimizations/validation/camera_intrinsic_calibration_validation.cpp
@@ -1,0 +1,50 @@
+#include <rct_optimizations/validation/camera_intrinsic_calibration_validation.h>
+
+namespace rct_optimizations
+{
+Eigen::Isometry3d getInternalTargetTransformation(const Correspondence2D3D::Set &correspondences,
+                                                  const CameraIntrinsics &intr,
+                                                  const Eigen::Isometry3d &camera_to_target_guess,
+                                                  const double residual_sq_error_threshold)
+{
+  // Create a lambda for doing the PnP optimization
+  auto solve_pnp = [&intr, &camera_to_target_guess, &residual_sq_error_threshold](
+                     const Correspondence2D3D::Set &corr) -> Eigen::Isometry3d {
+    // Create the first virtual target PnP problem
+    PnPProblem problem;
+    problem.intr = intr;
+    problem.correspondences = corr;
+    problem.camera_to_target_guess = camera_to_target_guess;
+
+    PnPResult result = optimize(problem);
+    if (!result.converged || result.final_cost_per_obs > residual_sq_error_threshold)
+    {
+      std::stringstream ss;
+      ss << "PnP optimization " << (result.converged ? "converged" : "did not converge")
+         << " with residual error of " << result.final_cost_per_obs << " ("
+         << residual_sq_error_threshold << " max)";
+      throw std::runtime_error(ss.str());
+    }
+
+    return result.camera_to_target;
+  };
+
+  // Calculate the size of half of the correspondence set
+  std::size_t half_size = correspondences.size() / 2;
+
+  // Create two half sets of correspondences
+  Correspondence2D3D::Set set_1(correspondences.begin(), correspondences.begin() + half_size);
+  Correspondence2D3D::Set set_2(correspondences.begin() + half_size, correspondences.end());
+
+  /* Get the camera to target transformation for each half set
+   * Note: these transforms are from the camera to the origin of each virtual target.
+   *   The origin of the second virtual target is still the same as the first virtual target,
+   *   so the two transforms should be the same, given perfect camera intrinsics */
+  Eigen::Isometry3d camera_to_target_1 = solve_pnp(set_1);
+  Eigen::Isometry3d camera_to_target_2 = solve_pnp(set_2);
+
+  // Return the transformation from target 1 to target 2
+  return camera_to_target_1.inverse() * camera_to_target_2;
+}
+
+} // namespace rct_optimizations

--- a/rct_optimizations/src/rct_optimizations/validation/camera_intrinsic_calibration_validation.cpp
+++ b/rct_optimizations/src/rct_optimizations/validation/camera_intrinsic_calibration_validation.cpp
@@ -5,9 +5,9 @@
 namespace rct_optimizations
 {
 VirtualCorrespondenceResult measureVirtualTargetDiff(const Correspondence2D3D::Set &correspondences,
-                                                 const CameraIntrinsics &intr,
-                                                 const Eigen::Isometry3d &camera_to_target_guess,
-                                                 const double pnp_sq_error_threshold)
+                                                     const CameraIntrinsics &intr,
+                                                     const Eigen::Isometry3d &camera_to_target_guess,
+                                                     const double pnp_sq_error_threshold)
 {
   // Create a lambda for doing the PnP optimization
   auto solve_pnp = [&intr, &camera_to_target_guess, &pnp_sq_error_threshold](
@@ -75,7 +75,9 @@ IntrinsicCalibrationAccuracyResult measureIntrinsicCalibrationAccuracy(
     // Check that the correspondences in all observations are the same size
     if (obs_1.correspondence_set.size() != obs_2.correspondence_set.size())
     {
-      throw std::runtime_error("They don't match");
+      std::stringstream ss;
+      ss << "Correspondence sizes do not match between observations " << i << " and " << i + 1;
+      throw std::runtime_error(ss.str());
     }
   }
 

--- a/rct_optimizations/test/CMakeLists.txt
+++ b/rct_optimizations/test/CMakeLists.txt
@@ -58,6 +58,13 @@ rct_gtest_discover_tests(${PROJECT_NAME}_pnp_tests)
 add_dependencies(${PROJECT_NAME}_pnp_tests ${PROJECT_NAME})
 add_dependencies(run_tests ${PROJECT_NAME}_pnp_tests)
 
+# Camera intrinsic calibration validation
+add_executable(${PROJECT_NAME}_camera_intrinsic_validation_tests camera_intrinsic_calibration_validation_utest.cpp)
+target_link_libraries(${PROJECT_NAME}_camera_intrinsic_validation_tests PRIVATE ${PROJECT_NAME}_test_support GTest::GTest GTest::Main)
+rct_gtest_discover_tests(${PROJECT_NAME}_camera_intrinsic_validation_tests)
+add_dependencies(${PROJECT_NAME}_camera_intrinsic_validation_tests ${PROJECT_NAME})
+add_dependencies(run_tests ${PROJECT_NAME}_camera_intrinsic_validation_tests)
+
 # Install the test executables so they can be run independently later if needed
 install(
   TARGETS
@@ -68,6 +75,7 @@ install(
     ${PROJECT_NAME}_dh_parameter_tests
     ${PROJECT_NAME}_extrinsic_hand_eye_dh_chain_tests
     ${PROJECT_NAME}_pnp_tests
+    ${PROJECT_NAME}_camera_intrinsic_validation_tests
   RUNTIME DESTINATION bin/tests
   LIBRARY DESTINATION lib/tests
   ARCHIVE DESTINATION lib/tests

--- a/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
+++ b/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
@@ -21,16 +21,19 @@ TEST(CameraIntrinsicCalibrationValidation, GetInternalTargetTransformationTest)
 
   Eigen::Isometry3d camera_to_target = base_to_camera.inverse() * base_to_target;
 
+  /* Since `getInternalTargetTransformation` simply splits the correspondences in half,
+     * creating two virtual targets with different features relative to the same origin,
+     * the expected transformation from one virtual target to the other should be identity */
+  const Eigen::Isometry3d expected(Eigen::Isometry3d::Identity());
+
   // Perfect camera intrinsics, perfect camera to target guess
   {
     Eigen::Isometry3d transform;
     EXPECT_NO_THROW(
       transform = getInternalTargetTransformation(corr_set, camera.intr, camera_to_target));
 
-    /* Since `getInternalTargetTransformation` simply splits the correspondences in half,
-     * creating two virtual targets with different features relative to the same origin,
-     * the transformation from one virtual target to the other should be identity */
-    EXPECT_TRUE(transform.isApprox(Eigen::Isometry3d::Identity()));
+    // Expect the transform to be almost exactly as expected
+    EXPECT_TRUE(transform.isApprox(expected));
   }
 
   // Create a slightly noisy camera to target guess (1 cm positional and ~5 degrees orientation noise)
@@ -42,10 +45,8 @@ TEST(CameraIntrinsicCalibrationValidation, GetInternalTargetTransformationTest)
     EXPECT_NO_THROW(
       transform = getInternalTargetTransformation(corr_set, camera.intr, camera_to_target_guess));
 
-    /* Since `getInternalTargetTransformation` simply splits the correspondences in half,
-     * creating two virtual targets with different features relative to the same origin,
-     * the transformation from one virtual target to the other should be identity */
-    EXPECT_TRUE(transform.isApprox(Eigen::Isometry3d::Identity(), 1.0e-8));
+    // Expect the transform to be very close to its expected value, but with a small error from the PnP
+    EXPECT_TRUE(transform.isApprox(expected, 1.0e-8));
   }
 
   // Bad camera intrinsics, imperfect camera to target guess
@@ -60,10 +61,8 @@ TEST(CameraIntrinsicCalibrationValidation, GetInternalTargetTransformationTest)
     EXPECT_NO_THROW(
       transform = getInternalTargetTransformation(corr_set, camera.intr, camera_to_target_guess));
 
-    /* Since `getInternalTargetTransformation` simply splits the correspondences in half,
-     * creating two virtual targets with different features relative to the same origin,
-     * the transformation from one virtual target to the other should be identity */
-    EXPECT_FALSE(transform.isApprox(Eigen::Isometry3d::Identity(), 1.0e-8));
+    // Expect the transform to be very close to its expected value, but with a small error from the PnP
+    EXPECT_FALSE(transform.isApprox(expected, 1.0e-8));
   }
 }
 

--- a/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
+++ b/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include <rct_optimizations/validation/camera_intrinsic_calibration_validation.h>
+#include <rct_optimizations_tests/utilities.h>
+#include <rct_optimizations_tests/observation_creator.h>
+
+using namespace rct_optimizations;
+
+TEST(CameraIntrinsicCalibrationValidation, GetInternalTargetTransformationTest)
+{
+  test::Target target(8, 6, 0.025);
+  test::Camera camera = test::makeKinectCamera();
+
+  // Create a camera pose directly above the target
+  Eigen::Isometry3d base_to_target(Eigen::Isometry3d::Identity());
+  Eigen::Isometry3d base_to_camera = base_to_target * Eigen::Translation3d(0.0, 0.0, 1.0)
+                                     * Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX());
+
+  Correspondence2D3D::Set corr_set;
+  ASSERT_NO_THROW(
+    corr_set = test::getCorrespondences(base_to_camera, base_to_target, camera, target, true));
+
+  Eigen::Isometry3d camera_to_target = base_to_camera.inverse() * base_to_target;
+
+  // Perfect camera intrinsics, perfect camera to target guess
+  {
+    Eigen::Isometry3d transform;
+    EXPECT_NO_THROW(
+      transform = getInternalTargetTransformation(corr_set, camera.intr, camera_to_target));
+
+    /* Since `getInternalTargetTransformation` simply splits the correspondences in half,
+     * creating two virtual targets with different features relative to the same origin,
+     * the transformation from one virtual target to the other should be identity */
+    EXPECT_TRUE(transform.isApprox(Eigen::Isometry3d::Identity()));
+  }
+
+  // Create a slightly noisy camera to target guess (1 cm positional and ~5 degrees orientation noise)
+  Eigen::Isometry3d camera_to_target_guess = test::perturbPose(camera_to_target, 0.01, 0.01);
+
+  // Perfect camera intrinsics, imperfect camera to target guess
+  {
+    Eigen::Isometry3d transform;
+    EXPECT_NO_THROW(
+      transform = getInternalTargetTransformation(corr_set, camera.intr, camera_to_target_guess));
+
+    /* Since `getInternalTargetTransformation` simply splits the correspondences in half,
+     * creating two virtual targets with different features relative to the same origin,
+     * the transformation from one virtual target to the other should be identity */
+    EXPECT_TRUE(transform.isApprox(Eigen::Isometry3d::Identity(), 1.0e-8));
+  }
+
+  // Bad camera intrinsics, imperfect camera to target guess
+  {
+    // Tweak the camera intrinsics slightly (+/- 5%)
+    camera.intr.fx() += 0.01 * camera.intr.fx();
+    camera.intr.fy() -= 0.01 * camera.intr.fy();
+    camera.intr.cx() -= 0.01 * camera.intr.cx();
+    camera.intr.cy() += 0.01 * camera.intr.cy();
+
+    Eigen::Isometry3d transform;
+    EXPECT_NO_THROW(
+      transform = getInternalTargetTransformation(corr_set, camera.intr, camera_to_target_guess));
+
+    /* Since `getInternalTargetTransformation` simply splits the correspondences in half,
+     * creating two virtual targets with different features relative to the same origin,
+     * the transformation from one virtual target to the other should be identity */
+    EXPECT_FALSE(transform.isApprox(Eigen::Isometry3d::Identity(), 1.0e-8));
+  }
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
+++ b/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
@@ -51,7 +51,7 @@ TEST(CameraIntrinsicCalibrationValidation, GetInternalTargetTransformationTest)
 
   // Bad camera intrinsics, imperfect camera to target guess
   {
-    // Tweak the camera intrinsics slightly (+/- 5%)
+    // Tweak the camera intrinsics slightly (+/- 1%)
     camera.intr.fx() += 0.01 * camera.intr.fx();
     camera.intr.fy() -= 0.01 * camera.intr.fy();
     camera.intr.cx() -= 0.01 * camera.intr.cx();

--- a/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
+++ b/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
@@ -87,19 +87,20 @@ TEST(CameraIntrinsicCalibrationValidation, MeasureIntrinsicCalibrationAccuracy)
   // Validate the intrinsic calibration
   // Perfect intrinsic parameters, perfect transform guesses
   {
-    IntrinsicCalibrationAccuracyResult result = measureIntrinsicCalibrationAccuracy(observations,
-                                                                 camera.intr,
-                                                                 camera_mount_to_camera,
-                                                                 target_mount_to_target,
-                                                                 camera_base_to_target_base);
+    IntrinsicCalibrationAccuracyResult result
+      = measureIntrinsicCalibrationAccuracy(observations,
+                                            camera.intr,
+                                            camera_mount_to_camera,
+                                            target_mount_to_target,
+                                            camera_base_to_target_base);
 
     // Expect results to be within 2 sigma (~95%) of the threshold
     {
-      double threshold = 1.0e-14;
+      double threshold = 1.0e-13;
       EXPECT_LT(result.pos_error.first + 2.0 * result.pos_error.second, threshold);
     }
     {
-      double threshold = 1.0e-14;
+      double threshold = 1.0e-13;
       EXPECT_LT(result.ang_error.first + 2.0 * result.ang_error.second, threshold);
     }
   }
@@ -114,11 +115,12 @@ TEST(CameraIntrinsicCalibrationValidation, MeasureIntrinsicCalibrationAccuracy)
 
   // Perfect intrinsic parameters, imperfect transform guesses
   {
-    IntrinsicCalibrationAccuracyResult result = measureIntrinsicCalibrationAccuracy(observations,
-                                                                 camera.intr,
-                                                                 camera_mount_to_camera_guess,
-                                                                 target_mount_to_target_guess,
-                                                                 camera_base_to_target_base);
+    IntrinsicCalibrationAccuracyResult result
+      = measureIntrinsicCalibrationAccuracy(observations,
+                                            camera.intr,
+                                            camera_mount_to_camera_guess,
+                                            target_mount_to_target_guess,
+                                            camera_base_to_target_base);
 
     // Expect results to be within 2 sigma (~95%) of the threshold
     {
@@ -139,11 +141,12 @@ TEST(CameraIntrinsicCalibrationValidation, MeasureIntrinsicCalibrationAccuracy)
     camera.intr.cx() -= 0.01 * camera.intr.cx();
     camera.intr.cx() += 0.01 * camera.intr.cy();
 
-    IntrinsicCalibrationAccuracyResult result = measureIntrinsicCalibrationAccuracy(observations,
-                                                                 camera.intr,
-                                                                 camera_mount_to_camera_guess,
-                                                                 target_mount_to_target_guess,
-                                                                 camera_base_to_target_base);
+    IntrinsicCalibrationAccuracyResult result
+      = measureIntrinsicCalibrationAccuracy(observations,
+                                            camera.intr,
+                                            camera_mount_to_camera_guess,
+                                            target_mount_to_target_guess,
+                                            camera_base_to_target_base);
 
     // Expect results not to be within 2 sigma (~95%) of the threshold because we modified the camera intrinsics
     {

--- a/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
+++ b/rct_optimizations/test/camera_intrinsic_calibration_validation_utest.cpp
@@ -2,6 +2,7 @@
 #include <rct_optimizations/validation/camera_intrinsic_calibration_validation.h>
 #include <rct_optimizations_tests/utilities.h>
 #include <rct_optimizations_tests/observation_creator.h>
+#include <memory>
 
 using namespace rct_optimizations;
 
@@ -70,7 +71,7 @@ TEST(CameraIntrinsicCalibrationValidation, MeasureIntrinsicCalibrationAccuracy)
 {
   test::Camera camera = test::makeKinectCamera();
   test::Target target(5, 7, 0.025);
-  test::GridPoseGenerator pose_gen;
+  auto pose_gen = std::make_shared<test::GridPoseGenerator>();
 
   // Create the relevant calibration transforms
   Eigen::Isometry3d camera_mount_to_camera(Eigen::Isometry3d::Identity());
@@ -80,7 +81,7 @@ TEST(CameraIntrinsicCalibrationValidation, MeasureIntrinsicCalibrationAccuracy)
   // Create some observations
   Observation2D3D::Set observations = test::createObservations(camera,
                                                                target,
-                                                               pose_gen,
+                                                               {pose_gen},
                                                                target_mount_to_target,
                                                                camera_mount_to_camera);
 

--- a/rct_optimizations/test/include/rct_optimizations_tests/utilities.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/utilities.h
@@ -27,6 +27,11 @@ Camera makeKinectCamera();
 
 /**
  * @brief A sample grid target for test purposes
+ * Looking down at the target
+ *   - The origin is in the lower left corner
+ *   - The x coordinate defines the feature column
+ *   - The y coordinate defines the feature row
+ *   - The points are ordered row-wise from the top left corner to the bottom right corner
  */
 struct Target
 {


### PR DESCRIPTION
This PR adds capability for validating the accuracy of a camera intrinsic calibration.

## Assumptions
Given a set of camera intrinsic parameters and a set of observations:
1. The correspondence set in each observation can be split into two independent correspondence sets
    - s1 = (c[0], ..., c[n/2])
    - s2 = (c[(n/2)+1], c[n])
1. A PnP optimization can accurately* determine the transformation of the origin of each virtual observation set relative to the camera
    - The residual error threshold for the PnP optimization can be specified to account for the noise level of the sensor
1. Although the two virtual correspondence sets contain different features, those features share the same origin. Therefore, the transform from the camera to the origin of both virtual correspondence sets should be the same, given perfect camera intrinsic parameters. For imperfect camera intrinsic parameters, there will be some error between the transforms
1. Calculating the mean and standard deviation between virtual correspondence sets for all observations provides a means of assessing the accuracy of the camera intrinsic calibration

## Results with the data set in `rct_examples`
### Using Kinect camera estimated intrinsic parameters
- Positional Error:
  - Mean (m): 0.00836456
  - Std. Dev. (m): 0.00868565
- Angular Error:
  - Mean (rad): 0.0327079
  - Std. Dev. (rad): 0.0242015

This means that the upper bound (mean + 2 sigma) of the transform error from one virtual correspondence set to the other was 25.7 mm and 4.64 degrees (i.e. really bad)

### Using Kinect camera calibrated intrinsic parameters
- Positional Error:
  - Mean (m): 0.00590141
    - Std. Dev. (m): 0.0058142
- Angular Error:
    - Mean (rad): 0.0273891
    - Std. Dev. (rad): 0.0218903

This means that the upper bound (mean + 2 sigma) of the transform error from one virtual correspondence set to the other was 17.5 mm and 4.07 degrees (i.e. still pretty bad)

These results along with @schornakj 's covariance analysis in #46 seem to show that there was probably a lack of data diversity in these images. We should eventually create a data set of really good intrinsic calibration images with which to run this test.