### PR TITLE
CI Update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,22 +8,24 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - {OS_NAME: ubuntu,
+          - {BADGE: bionic,
+             OS_NAME: ubuntu,
              OS_CODE_NAME: bionic,
              ROS_DISTRO: melodic,
              ROS_REPO: main,
              ADDITIONAL_DEBS: git,
              VERBOSE_TESTS: true,
-             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=True -DRCT_RUN_TESTS=True",
-             BADGE: bionic}
-          - {OS_NAME: ubuntu,
+             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=ON",
+             AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose rct_optimizations --make-args test'}
+          - {BADGE: xenial,
+             OS_NAME: ubuntu,
              OS_CODE_NAME: xenial,
              ROS_DISTRO: kinetic,
              ROS_REPO: main,
              ADDITIONAL_DEBS: git,
              VERBOSE_TESTS: true,
-             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=True -DRCT_RUN_TESTS=True",
-             BADGE: xenial}
+             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=ON",
+             AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose rct_optimizations --make-args test'}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This PR changes the way that unit tests are run for pure CMake packages such that the CTest error log is printed to the CI log. Instead of passing the `-DRCT_RUN_TESTS` argument at build time (which hides the output of CTest, possibly due to `industrial_ci` settings which make the build less verbose), I added an `AFTER_SCRIPT` argument that builds only the pure CMake packages verbosely with a `test` `make` argument. This was @Levi-Armstrong 's approach to getting output from CTest into the CI log because making the build itself verbose would overflow the log