### PR TITLE
Allow PoseGenerators to generate a greater variety of poses

### DIFF
--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -256,7 +256,7 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions)
 
 TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions_MoreHemispheres)
 {
-  const std::size_t n = 10;
+  const std::size_t n = 1;
   const std::size_t max_attempts = 2 * n;
   std::size_t count = 0;
 
@@ -265,8 +265,8 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions_MoreHemispheres)
   offset.translation().x() = 0.1;
 
   std::vector<std::shared_ptr<test::PoseGenerator>> pgs;
-  pgs.push_back(std::make_shared<test::RandomZRotHemispherePoseGenerator>(2.0, 10, 10, Eigen::Isometry3d::Identity()));
-  pgs.push_back(std::make_shared<test::RandomZRotHemispherePoseGenerator>(2.0, 10, 10, offset));
+  pgs.push_back(std::make_shared<test::RandomZRotPoseGenerator>(std::make_shared<test::HemispherePoseGenerator>(2.0, 10, 10, 0.0, Eigen::Isometry3d::Identity())));
+  pgs.push_back(std::make_shared<test::RandomZRotPoseGenerator>(std::make_shared<test::HemispherePoseGenerator>(2.0, 10, 10, 0.0, offset)));
 
   while(count < n && count < max_attempts)
   {

--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -260,9 +260,13 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions_MoreHemispheres)
   const std::size_t max_attempts = 2 * n;
   std::size_t count = 0;
 
+
+  Eigen::Isometry3d offset = Eigen::Isometry3d::Identity();
+  offset.translation().x() = 0.1;
+
   std::vector<std::shared_ptr<test::PoseGenerator>> pgs;
-//  pgs.push_back(std::make_shared<test::HemispherePoseGenerator>(2.0, 10, 10));
-  pgs.push_back(std::make_shared<test::HemispherePoseGenerator>(2.0, 10, 10, 0.5 * M_PI));
+  pgs.push_back(std::make_shared<test::RandomZRotHemispherePoseGenerator>(2.0, 10, 10, Eigen::Isometry3d::Identity()));
+  pgs.push_back(std::make_shared<test::RandomZRotHemispherePoseGenerator>(2.0, 10, 10, offset));
 
   while(count < n && count < max_attempts)
   {

--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -39,7 +39,13 @@ struct ProblemCreator
 
   static ProblemT createProblem(const Eigen::Isometry3d &true_target,
                                 const Eigen::Isometry3d &true_camera,
-                                const test::PoseGenerator& pose_generator,
+                                const std::shared_ptr<test::PoseGenerator>& pose_generator,
+                                const test::Target &target,
+                                const InitialConditions &init);
+
+  static ProblemT createProblem(const Eigen::Isometry3d &true_target,
+                                const Eigen::Isometry3d &true_camera,
+                                const std::vector<std::shared_ptr<test::PoseGenerator>>& pose_generators,
                                 const test::Target &target,
                                 const InitialConditions &init);
 
@@ -52,7 +58,7 @@ template<>
 ExtrinsicHandEyeProblem2D3D ProblemCreator<ExtrinsicHandEyeProblem2D3D>::createProblem(
   const Eigen::Isometry3d &true_target,
   const Eigen::Isometry3d &true_camera,
-  const test::PoseGenerator& pose_generator,
+  const std::vector<std::shared_ptr<test::PoseGenerator>>& pose_generators,
   const test::Target &target,
   const InitialConditions &init)
 {
@@ -64,11 +70,23 @@ ExtrinsicHandEyeProblem2D3D ProblemCreator<ExtrinsicHandEyeProblem2D3D>::createP
   problem.camera_mount_to_camera_guess = createPose(true_camera, init);
   problem.observations = test::createObservations(camera,
                                                   target,
-                                                  pose_generator,
+                                                  pose_generators,
                                                   true_target,
                                                   true_camera);
 
   return problem;
+}
+
+
+template<>
+ExtrinsicHandEyeProblem2D3D ProblemCreator<ExtrinsicHandEyeProblem2D3D>::createProblem(
+  const Eigen::Isometry3d &true_target,
+  const Eigen::Isometry3d &true_camera,
+  const std::shared_ptr<test::PoseGenerator>& pose_generator,
+  const test::Target &target,
+  const InitialConditions &init)
+{
+  return ProblemCreator<ExtrinsicHandEyeProblem2D3D>::createProblem(true_target, true_camera, std::vector<std::shared_ptr<test::PoseGenerator>>({pose_generator}), target, init);
 }
 
 template<>
@@ -78,16 +96,26 @@ template<>
 ExtrinsicHandEyeProblem3D3D ProblemCreator<ExtrinsicHandEyeProblem3D3D>::createProblem(
   const Eigen::Isometry3d &true_target,
   const Eigen::Isometry3d &true_camera,
-  const test::PoseGenerator& pose_generator,
+  const std::vector<std::shared_ptr<test::PoseGenerator>>& pose_generators,
   const test::Target &target,
   const InitialConditions &init)
 {
   ExtrinsicHandEyeProblem3D3D problem;
   problem.target_mount_to_target_guess = createPose(true_target, init);
   problem.camera_mount_to_camera_guess = createPose(true_camera, init);
-  problem.observations = test::createObservations(target, pose_generator, true_target, true_camera);
-
+  problem.observations = test::createObservations(target, pose_generators, true_target, true_camera);
   return problem;
+}
+
+template<>
+ExtrinsicHandEyeProblem3D3D ProblemCreator<ExtrinsicHandEyeProblem3D3D>::createProblem(
+  const Eigen::Isometry3d &true_target,
+  const Eigen::Isometry3d &true_camera,
+  const std::shared_ptr<test::PoseGenerator>& pose_generator,
+  const test::Target &target,
+  const InitialConditions &init)
+{
+  return ProblemCreator<ExtrinsicHandEyeProblem3D3D>::createProblem(true_target, true_camera, std::vector<std::shared_ptr<test::PoseGenerator>>({pose_generator}), target, init);
 }
 
 template<>
@@ -142,7 +170,7 @@ TYPED_TEST_CASE(HandEyeTest, Implementations);
 
 TYPED_TEST(HandEyeTest, PerfectInitialConditions)
 {
-  test::HemispherePoseGenerator pg;
+  auto pg = std::make_shared<test::HemispherePoseGenerator>();
   TypeParam prob = ProblemCreator<TypeParam>::createProblem(this->true_target_mount_to_target,
                                                             this->true_camera_mount_to_camera,
                                                             pg,
@@ -178,7 +206,7 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions)
   const std::size_t max_attempts = 2 * n;
   std::size_t count = 0;
 
-  test::HemispherePoseGenerator pg;
+  auto pg = std::make_shared<test::HemispherePoseGenerator>();
 
   while(count < n && count < max_attempts)
   {
@@ -186,6 +214,62 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions)
       = ProblemCreator<TypeParam>::createProblem(this->true_target_mount_to_target,
                                                  this->true_camera_mount_to_camera,
                                                  pg,
+                                                 this->target,
+                                                 InitialConditions::RANDOM_AROUND_ANSWER);
+    // Run the optimization
+    // Catch exceptions during the optimization because there is a good chance that infeasible initial
+    // transform guesses will be randomly generated
+    ExtrinsicHandEyeResult result;
+    try
+    {
+      result = optimize(prob);
+    }
+    catch (const std::exception &ex)
+    {
+      std::cout << "Exception from optimization; continuing: '" << ex.what() << "'" << std::endl;
+      continue;
+    }
+
+    ++count;
+
+    // Make sure it converged to the correct answer
+    EXPECT_TRUE(result.converged);
+    EXPECT_TRUE(result.final_cost_per_obs < ProblemCreator<TypeParam>::max_cost_per_obs);
+
+    EXPECT_TRUE(result.target_mount_to_target.isApprox(this->true_target_mount_to_target, 1e-6));
+    EXPECT_TRUE(result.camera_mount_to_camera.isApprox(this->true_camera_mount_to_camera, 1e-6));
+
+    EXPECT_EQ(result.covariance_camera_mount_to_camera.rows(), 6);
+    EXPECT_EQ(result.covariance_camera_mount_to_camera.cols(), 6);
+
+    EXPECT_EQ(result.covariance_target_mount_to_target.rows(), 6);
+    EXPECT_EQ(result.covariance_target_mount_to_target.cols(), 6);
+
+    EXPECT_EQ(result.covariance_tform_target_to_tform_camera.rows(), 6);
+    EXPECT_EQ(result.covariance_tform_target_to_tform_camera.cols(), 6);
+
+    this->printResults(result);
+  }
+  EXPECT_EQ(count, n);
+  EXPECT_LT(count, max_attempts);
+}
+
+TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions_MoreHemispheres)
+{
+  const std::size_t n = 10;
+  const std::size_t max_attempts = 2 * n;
+  std::size_t count = 0;
+
+  std::vector<std::shared_ptr<test::PoseGenerator>> pgs;
+//  pgs.push_back(std::make_shared<test::HemispherePoseGenerator>(2.0, 10, 10));
+  pgs.push_back(std::make_shared<test::HemispherePoseGenerator>(2.0, 10, 10, 0.5 * M_PI));
+
+  while(count < n && count < max_attempts)
+  {
+    TypeParam prob
+      = ProblemCreator<TypeParam>::createProblem(this->true_target_mount_to_target,
+                                                 this->true_camera_mount_to_camera,
+                                                 pgs,
                                                  this->target,
                                                  InitialConditions::RANDOM_AROUND_ANSWER);
     // Run the optimization

--- a/rct_optimizations/test/include/rct_optimizations_tests/observation_creator.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/observation_creator.h
@@ -42,7 +42,7 @@ Correspondence3D3D::Set getCorrespondences(const Eigen::Isometry3d &camera_pose,
  * @brief Creates a 2D-3D observation set
  * @param camera - camera intrinsics
  * @param target - target definition
- * @param pose_generator - base class for camera pose generation
+ * @param pose_generators - vector of shared pointers to variants of base class for camera pose generation
  * @param true_target_mount_to_target - the true transform from the target mount to the target
  * @param true_camera_mount_to_camera - the true transform from the camera mount to the camera
  * @param camera_base_to_target_base - the transform from the camera base frame to the target base frame (typically identity)
@@ -51,7 +51,7 @@ Correspondence3D3D::Set getCorrespondences(const Eigen::Isometry3d &camera_pose,
 Observation2D3D::Set createObservations(
   const Camera &camera,
   const Target &target,
-  const PoseGenerator &pose_generator,
+  const std::vector<std::shared_ptr<PoseGenerator>> &pose_generators,
   const Eigen::Isometry3d &true_target_mount_to_target,
   const Eigen::Isometry3d &true_camera_mount_to_camera,
   const Eigen::Isometry3d &camera_base_to_target_base = Eigen::Isometry3d::Identity());
@@ -59,7 +59,7 @@ Observation2D3D::Set createObservations(
 /**
  * @brief Creates a 3D-3D observation set
  * @param target - target definition
- * @param pose_generator - base class for camera pose generation
+ * @param pose_generators - vector of shared pointers to variants of base class for camera pose generation
  * @param true_target_mount_to_target - the true transform from the target mount to the target
  * @param true_camera_mount_to_camera - the true transform from the camera mount to the camera
  * @param camera_base_to_target_base - the transform from the camera base frame to the target base frame (typically identity)
@@ -67,7 +67,7 @@ Observation2D3D::Set createObservations(
  */
 Observation3D3D::Set createObservations(
   const Target &target,
-  const PoseGenerator &pose_generator,
+  const std::vector<std::shared_ptr<PoseGenerator>> &pose_generators,
   const Eigen::Isometry3d &true_target_mount_to_target,
   const Eigen::Isometry3d &true_camera_mount_to_camera,
   const Eigen::Isometry3d &camera_base_to_target_base = Eigen::Isometry3d::Identity());

--- a/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
@@ -35,7 +35,6 @@ struct PoseGenerator
  */
 struct HemispherePoseGenerator : PoseGenerator
 {
-public:
   inline HemispherePoseGenerator(double r_,
                                  unsigned theta_cnt_,
                                  unsigned phi_cnt_,
@@ -78,7 +77,6 @@ public:
  */
 struct ConicalPoseGenerator : PoseGenerator
 {
-protected:
   inline ConicalPoseGenerator(double r_,
                               double h_,
                               unsigned n_poses_,
@@ -122,7 +120,6 @@ protected:
  */
 struct GridPoseGenerator : PoseGenerator
 {
-public:
   inline GridPoseGenerator(double spacing_,
                            double h_,
                            unsigned grid_side_,
@@ -160,7 +157,9 @@ public:
   Eigen::Isometry3d target_offset; /** @brief Transform from target origin to origin of pose pattern */
 };
 
-
+/**
+ * @brief Applies a random rotation around the camera Z+ axis in range [@ref z_rot_min_, @ref z_rot_max_]
+ */
 struct RandomZRotPoseGenerator : PoseGenerator
 {
   inline RandomZRotPoseGenerator(const std::shared_ptr<PoseGenerator>& pg_,

--- a/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
@@ -146,6 +146,14 @@ public:
 
   }
 
+  inline ConicalPoseGenerator(double r_,
+                              double h_,
+                              unsigned n_poses_)
+    : ConicalPoseGenerator(r_, h_, n_poses_, 0.0, Eigen::Isometry3d::Identity())
+  {
+
+  }
+
   inline ConicalPoseGenerator()
     : ConicalPoseGenerator(1.0, 2.0, 20, 0.0, Eigen::Isometry3d::Identity())
   {
@@ -211,9 +219,28 @@ protected:
   }
 
 public:
+  inline GridPoseGenerator(double spacing_,
+                           double h_,
+                           unsigned grid_side_,
+                           double z_rot_,
+                           const Eigen::Isometry3d& target_offset_)
+    : GridPoseGenerator(spacing_, h_, grid_side_, z_rot_, z_rot_, target_offset_)
+  {
+
+  }
+
+  inline GridPoseGenerator(double spacing_,
+                           double h_,
+                           unsigned grid_side_)
+    : GridPoseGenerator(spacing_, h_, grid_side_, 0.0, Eigen::Isometry3d::Identity())
+  {
+
+  }
+
   inline GridPoseGenerator()
     : GridPoseGenerator(0.2, 2.0, 10, 0.0, 0.0, Eigen::Isometry3d::Identity())
   {
+
   }
 
   virtual std::vector<Eigen::Isometry3d> generate(

--- a/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
@@ -25,7 +25,7 @@ struct PoseGenerator
    * @param target_origin The position of the target
    * @return A vector of camera positions & orientations
    */
-  virtual std::vector<Eigen::Isometry3d> generate(const Eigen::Vector3d &target_origin) const = 0;
+  virtual std::vector<Eigen::Isometry3d> generate(const Eigen::Isometry3d &target_origin) const = 0;
 };
 
 /**
@@ -47,7 +47,7 @@ struct HemispherePoseGenerator : PoseGenerator
   }
 
   virtual std::vector<Eigen::Isometry3d> generate(
-    const Eigen::Vector3d &target_origin) const override final;
+    const Eigen::Isometry3d &target_origin) const override final;
 
   double r; /* @brief Radius of the hemisphere */
   unsigned theta_cnt; /* @brief The number of points in the theta-wise direction*/
@@ -75,7 +75,7 @@ struct ConicalPoseGenerator : PoseGenerator
   }
 
   virtual std::vector<Eigen::Isometry3d> generate(
-    const Eigen::Vector3d &target_origin) const override final;
+    const Eigen::Isometry3d &target_origin) const override final;
 
   double r; /** @brief Radius of the cone*/
   double h; /** @brief Height of the cone (distance to target) */
@@ -103,7 +103,7 @@ struct GridPoseGenerator : PoseGenerator
   }
 
   virtual std::vector<Eigen::Isometry3d> generate(
-    const Eigen::Vector3d &target_origin) const override final;
+    const Eigen::Isometry3d &target_origin) const override final;
 
   double spacing; /** @brief Distance betweeon points */
   double h; /** @brief Grid distance to target */

--- a/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
@@ -35,10 +35,14 @@ struct HemispherePoseGenerator : PoseGenerator
 {
   inline HemispherePoseGenerator(double r_ = 2.0,
                                  unsigned theta_cnt_ = 10,
-                                 unsigned phi_cnt_ = 10)
+                                 unsigned phi_cnt_ = 10,
+                                 double z_rot_ = 0.0,
+                                 const Eigen::Isometry3d& target_offset_ = Eigen::Isometry3d::Identity())
     : r(r_)
     , theta_cnt(theta_cnt_)
     , phi_cnt(phi_cnt_)
+    , z_rot(z_rot_)
+    , target_offset(target_offset_)
   {
   }
 
@@ -48,6 +52,8 @@ struct HemispherePoseGenerator : PoseGenerator
   double r; /* @brief Radius of the hemisphere */
   unsigned theta_cnt; /* @brief The number of points in the theta-wise direction*/
   unsigned phi_cnt; /* @brief The number of points in the phi-wise direction */
+  double z_rot; /* @brief Rotation to apply around camera Z-axis (radians) */
+  Eigen::Isometry3d target_offset; /* @brief Transform from target origin to origin of pose pattern */
 };
 
 /**
@@ -57,10 +63,14 @@ struct ConicalPoseGenerator : PoseGenerator
 {
   inline ConicalPoseGenerator(double r_ = 1.0,
                               double h_ = 2.0,
-                              unsigned n_poses_ = 20)
+                              unsigned n_poses_ = 20,
+                              double z_rot_ = 0.0,
+                              const Eigen::Isometry3d& target_offset_ = Eigen::Isometry3d::Identity())
     : r(r_)
     , h(h_)
     , n_poses(n_poses_)
+    , z_rot(z_rot_)
+    , target_offset(target_offset_)
   {
   }
 
@@ -70,16 +80,25 @@ struct ConicalPoseGenerator : PoseGenerator
   double r; /** @brief Radius of the cone*/
   double h; /** @brief Height of the cone (distance to target) */
   unsigned n_poses; /** @brief Number of poses to generate */
+  double z_rot; /* @brief Rotation to apply around camera Z-axis (radians) */
+  Eigen::Isometry3d target_offset; /* @brief Transform from target origin to origin of pose pattern */
 };
 
+/**
+ * @brief Generates poses in a grid
+ */
 struct GridPoseGenerator : PoseGenerator
 {
   inline GridPoseGenerator(double spacing_ = 0.2,
                            double h_ = 2.0,
-                           unsigned grid_side_ = 10)
+                           unsigned grid_side_ = 10,
+                           double z_rot_ = 0.0,
+                           const Eigen::Isometry3d& target_offset_ = Eigen::Isometry3d::Identity())
     : spacing(spacing_)
     , h(h_)
     , grid_side(grid_side_)
+    , z_rot(z_rot_)
+    , target_offset(target_offset_)
   {
   }
 
@@ -89,6 +108,8 @@ struct GridPoseGenerator : PoseGenerator
   double spacing; /** @brief Distance betweeon points */
   double h; /** @brief Grid distance to target */
   unsigned grid_side; /** number of columns & rows to go into grid */
+  double z_rot; /* @brief Rotation to apply around camera Z-axis (radians) */
+  Eigen::Isometry3d target_offset; /* @brief Transform from target origin to origin of pose pattern */
 };
 
 }  // namespace test

--- a/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/pose_generator.h
@@ -35,31 +35,17 @@ struct PoseGenerator
  */
 struct HemispherePoseGenerator : PoseGenerator
 {
-protected:
-  inline HemispherePoseGenerator(double r_,
-                                 unsigned theta_cnt_,
-                                 unsigned phi_cnt_,
-                                 double z_rot_min_,
-                                 double z_rot_max_,
-                                 const Eigen::Isometry3d& target_offset_,
-                                 unsigned long seed_ = std::mt19937::default_seed)
-    : r(r_)
-    , theta_cnt(theta_cnt_)
-    , phi_cnt(phi_cnt_)
-    , target_offset(target_offset_)
-    , mt_rand(seed_)
-    , z_sampler(z_rot_min_, z_rot_max_)
-  {
-
-  }
-
 public:
   inline HemispherePoseGenerator(double r_,
                                  unsigned theta_cnt_,
                                  unsigned phi_cnt_,
                                  double z_rot_,
                                  const Eigen::Isometry3d& target_offset_)
-    : HemispherePoseGenerator(r_, theta_cnt_, phi_cnt_, z_rot_, z_rot_, target_offset_)
+    : r(r_)
+    , theta_cnt(theta_cnt_)
+    , phi_cnt(phi_cnt_)
+    , z_rot(z_rot_)
+    , target_offset(target_offset_)
   {
 
   }
@@ -82,33 +68,10 @@ public:
   double r; /** @brief Radius of the hemisphere */
   unsigned theta_cnt; /** @brief The number of points in the theta-wise direction*/
   unsigned phi_cnt; /** @brief The number of points in the phi-wise direction */
+  double z_rot; /** @brief Rotation about camera Z+ */
   Eigen::Isometry3d target_offset; /** @brief Transform from target origin to origin of pose pattern */
-
-private:
-  std::mt19937 mt_rand; /** @brief Psuedo-random number generator */
-  std::uniform_real_distribution<double> z_sampler; /** @brief Sampler for camera Z+ rotation */
 };
 
-/**
- * @brief Generates camera poses in a hemisphere pattern. Randomly vary rotation around the camera Z+ axis.
- */
-struct RandomZRotHemispherePoseGenerator : HemispherePoseGenerator
-{
-  inline RandomZRotHemispherePoseGenerator(double r_,
-                                           unsigned theta_cnt_,
-                                           unsigned phi_cnt_,
-                                           const Eigen::Isometry3d& target_offset_)
-    : HemispherePoseGenerator (r_, theta_cnt_, phi_cnt_, 0.0, 2 * M_PI, target_offset_)
-  {
-
-  }
-
-  inline RandomZRotHemispherePoseGenerator()
-    : RandomZRotHemispherePoseGenerator(2.0, 10, 10, Eigen::Isometry3d::Identity())
-  {
-
-  }
-};
 
 /**
  * @brief Generates camera positions using a conical template, with the target at the 'point'
@@ -119,28 +82,14 @@ protected:
   inline ConicalPoseGenerator(double r_,
                               double h_,
                               unsigned n_poses_,
-                              double z_rot_min_,
-                              double z_rot_max_,
-                              const Eigen::Isometry3d& target_offset_,
-                              unsigned long seed_ = std::mt19937::default_seed)
+                              double z_rot_,
+                              const Eigen::Isometry3d& target_offset_)
     : r(r_)
     , h(h_)
     , n_poses(n_poses_)
+    , z_rot(z_rot_)
     , target_offset(target_offset_)
-    , mt_rand(seed_)
-    , z_sampler(z_rot_min_, z_rot_max_)
   {
-  }
-
-public:
-  inline ConicalPoseGenerator(double r_,
-                              double h_,
-                              unsigned n_poses_,
-                              double z_rot_,
-                              const Eigen::Isometry3d& target_offset_)
-    : ConicalPoseGenerator(r_, h_, n_poses_, z_rot_, z_rot_, target_offset_)
-  {
-
   }
 
   inline ConicalPoseGenerator(double r_,
@@ -163,65 +112,28 @@ public:
   double r; /** @brief Radius of the cone*/
   double h; /** @brief Height of the cone (distance to target) */
   unsigned n_poses; /** @brief Number of poses to generate */
-  Eigen::Isometry3d target_offset; /* @brief Transform from target origin to origin of pose pattern */
-
-private:
-  std::mt19937 mt_rand; /** @brief Psuedo-random number generator */
-  std::uniform_real_distribution<double> z_sampler; /** @brief Sampler for camera Z+ rotation */
+  double z_rot; /** @brief Rotation about camera Z+ */
+  Eigen::Isometry3d target_offset; /** @brief Transform from target origin to origin of pose pattern */
 };
 
-/**
- * @brief Generates camera positions using a conical template, with the target at the 'point'. Randomly vary rotation around the camera Z+ axis.
- */
-struct RandomZRotConicalPoseGenerator : ConicalPoseGenerator
-{
-  inline RandomZRotConicalPoseGenerator(double r_,
-                                        double h_,
-                                        unsigned n_poses_,
-                                        const Eigen::Isometry3d& target_offset_)
-    : ConicalPoseGenerator (r_, h_, n_poses_, 0.0, 2 * M_PI, target_offset_)
-  {
-
-  }
-
-  inline RandomZRotConicalPoseGenerator()
-    : RandomZRotConicalPoseGenerator(1.0, 2.0, 20, Eigen::Isometry3d::Identity())
-  {
-
-  }
-};
 
 /**
  * @brief Generates poses in a grid
  */
 struct GridPoseGenerator : PoseGenerator
 {
-protected:
-  inline GridPoseGenerator(double spacing_,
-                           double h_,
-                           unsigned grid_side_,
-                           double z_rot_min_,
-                           double z_rot_max_,
-                           const Eigen::Isometry3d& target_offset_,
-                           unsigned long seed_ = std::mt19937::default_seed)
-    : spacing(spacing_)
-    , h(h_)
-    , grid_side(grid_side_)
-    , target_offset(target_offset_)
-    , mt_rand(seed_)
-    , z_sampler(z_rot_min_, z_rot_max_)
-  {
-  }
-
 public:
   inline GridPoseGenerator(double spacing_,
                            double h_,
                            unsigned grid_side_,
                            double z_rot_,
                            const Eigen::Isometry3d& target_offset_)
-    : GridPoseGenerator(spacing_, h_, grid_side_, z_rot_, z_rot_, target_offset_)
+    : spacing(spacing_)
+    , h(h_)
+    , grid_side(grid_side_)
+    , z_rot(z_rot_)
+    , target_offset(target_offset_)
   {
-
   }
 
   inline GridPoseGenerator(double spacing_,
@@ -233,7 +145,7 @@ public:
   }
 
   inline GridPoseGenerator()
-    : GridPoseGenerator(0.2, 2.0, 10, 0.0, 0.0, Eigen::Isometry3d::Identity())
+    : GridPoseGenerator(0.2, 2.0, 10, 0.0, Eigen::Isometry3d::Identity())
   {
 
   }
@@ -246,32 +158,8 @@ public:
   unsigned grid_side; /** @brief number of columns & rows to go into grid */
   double z_rot; /** @brief Rotation to apply around camera Z-axis (radians) */
   Eigen::Isometry3d target_offset; /** @brief Transform from target origin to origin of pose pattern */
-
-private:
-  std::mt19937 mt_rand; /** @brief Psuedo-random number generator */
-  std::uniform_real_distribution<double> z_sampler; /** @brief Sampler for camera Z+ rotation */
 };
 
-/**
- * @brief Generate poses in a grid. Randomly vary rotation around the camera Z+ axis.
- */
-struct RandomZRotGridPoseGenerator : GridPoseGenerator
-{
-  inline RandomZRotGridPoseGenerator(double spacing_,
-                                     double h_,
-                                     unsigned grid_side_,
-                                     const Eigen::Isometry3d& target_offset_)
-    : GridPoseGenerator (spacing_, h_, grid_side_, 0.0, 2 * M_PI, target_offset_)
-  {
-
-  }
-
-  inline RandomZRotGridPoseGenerator()
-    : RandomZRotGridPoseGenerator(0.2, 2.0, 10, Eigen::Isometry3d::Identity())
-  {
-
-  }
-};
 
 struct RandomZRotPoseGenerator : PoseGenerator
 {

--- a/rct_optimizations/test/src/observation_creator.cpp
+++ b/rct_optimizations/test/src/observation_creator.cpp
@@ -80,13 +80,11 @@ Observation2D3D::Set createObservations(const Camera &camera,
                                         const Eigen::Isometry3d &true_camera_mount_to_camera,
                                         const Eigen::Isometry3d &camera_base_to_target_base)
 {
-  const Eigen::Vector3d &target_origin = true_target_mount_to_target.translation();
-
   // Generate camera poses relative to the target origin
   std::vector<Eigen::Isometry3d> camera_poses;
   for (auto it = pose_generators.begin(); it != pose_generators.end(); ++it)
   {
-    auto new_poses = it->get()->generate(target_origin);
+    auto new_poses = it->get()->generate(true_target_mount_to_target);
     camera_poses.insert(camera_poses.end(), new_poses.begin(), new_poses.end());
   }
 
@@ -127,13 +125,11 @@ Observation3D3D::Set createObservations(const Target &target,
                                         const Eigen::Isometry3d &true_camera_mount_to_camera,
                                         const Eigen::Isometry3d &camera_base_to_target_base)
 {
-  const Eigen::Vector3d &target_origin = true_target_mount_to_target.translation();
-
   // Generate camera poses relative to the target origin
   std::vector<Eigen::Isometry3d> camera_poses;
   for (auto it = pose_generators.begin(); it != pose_generators.end(); ++it)
   {
-    auto new_poses = it->get()->generate(target_origin);
+    auto new_poses = it->get()->generate(true_target_mount_to_target);
     camera_poses.insert(camera_poses.end(), new_poses.begin(), new_poses.end());
   }
 

--- a/rct_optimizations/test/src/observation_creator.cpp
+++ b/rct_optimizations/test/src/observation_creator.cpp
@@ -75,7 +75,7 @@ Correspondence3D3D::Set getCorrespondences(const Eigen::Isometry3d &camera_pose,
 
 Observation2D3D::Set createObservations(const Camera &camera,
                                         const Target &target,
-                                        const PoseGenerator &pose_generator,
+                                        const std::vector<std::shared_ptr<PoseGenerator>> &pose_generators,
                                         const Eigen::Isometry3d &true_target_mount_to_target,
                                         const Eigen::Isometry3d &true_camera_mount_to_camera,
                                         const Eigen::Isometry3d &camera_base_to_target_base)
@@ -83,7 +83,12 @@ Observation2D3D::Set createObservations(const Camera &camera,
   const Eigen::Vector3d &target_origin = true_target_mount_to_target.translation();
 
   // Generate camera poses relative to the target origin
-  std::vector<Eigen::Isometry3d> camera_poses = pose_generator.generate(target_origin);
+  std::vector<Eigen::Isometry3d> camera_poses;
+  for (auto it = pose_generators.begin(); it != pose_generators.end(); ++it)
+  {
+    auto new_poses = it->get()->generate(target_origin);
+    camera_poses.insert(camera_poses.end(), new_poses.begin(), new_poses.end());
+  }
 
   Observation2D3D::Set observations;
   observations.reserve(camera_poses.size());
@@ -117,7 +122,7 @@ Observation2D3D::Set createObservations(const Camera &camera,
 }
 
 Observation3D3D::Set createObservations(const Target &target,
-                                        const PoseGenerator &pose_generator,
+                                        const std::vector<std::shared_ptr<PoseGenerator>> &pose_generators,
                                         const Eigen::Isometry3d &true_target_mount_to_target,
                                         const Eigen::Isometry3d &true_camera_mount_to_camera,
                                         const Eigen::Isometry3d &camera_base_to_target_base)
@@ -125,7 +130,12 @@ Observation3D3D::Set createObservations(const Target &target,
   const Eigen::Vector3d &target_origin = true_target_mount_to_target.translation();
 
   // Generate camera poses relative to the target origin
-  std::vector<Eigen::Isometry3d> camera_poses = pose_generator.generate(target_origin);
+  std::vector<Eigen::Isometry3d> camera_poses;
+  for (auto it = pose_generators.begin(); it != pose_generators.end(); ++it)
+  {
+    auto new_poses = it->get()->generate(target_origin);
+    camera_poses.insert(camera_poses.end(), new_poses.begin(), new_poses.end());
+  }
 
   Observation3D3D::Set observations;
   observations.reserve(camera_poses.size());

--- a/rct_optimizations/test/src/pose_generator.cpp
+++ b/rct_optimizations/test/src/pose_generator.cpp
@@ -53,7 +53,7 @@ std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Is
       // x is 'up' in target frame
       Eigen::Isometry3d camera_oriented = target_offset
                                         * lookAt(camera.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
-                                        * Eigen::Isometry3d(Eigen::AngleAxisd(getZRot(), Eigen::Vector3d::UnitZ()));
+                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_sampler(mt_rand), Eigen::Vector3d::UnitZ()));
 
       // this vector is still in target spatial coordinates
       camera_positions.push_back(camera_oriented);
@@ -63,10 +63,6 @@ std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Is
   return camera_positions;
 }
 
-double HemispherePoseGenerator::getZRot()
-{
-  return z_sampler(mt_rand);
-}
 
 // cone
 std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Isometry3d &target_origin)
@@ -87,17 +83,12 @@ std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Isome
     // change orientation to look at target
     Eigen::Isometry3d camera_oriented = target_offset
                                       * lookAt(camera_pose.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
-                                      * Eigen::Isometry3d(Eigen::AngleAxisd(getZRot(), Eigen::Vector3d::UnitZ()));
+                                      * Eigen::Isometry3d(Eigen::AngleAxisd(z_sampler(mt_rand), Eigen::Vector3d::UnitZ()));
 
     camera_positions.push_back(camera_oriented);
   }
 
   return camera_positions;
-}
-
-double ConicalPoseGenerator::getZRot()
-{
-  return z_sampler(mt_rand);
 }
 
 // grid
@@ -121,7 +112,7 @@ std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Isometry
       // change orientation to look at target
       Eigen::Isometry3d camera_oriented = target_offset
                                         * lookAt(camera_pose.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
-                                        * Eigen::Isometry3d(Eigen::AngleAxisd(getZRot(), Eigen::Vector3d::UnitZ()));
+                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_sampler(mt_rand), Eigen::Vector3d::UnitZ()));
 
       camera_positions.push_back(camera_oriented);
     }
@@ -130,9 +121,14 @@ std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Isometry
   return camera_positions;
 }
 
-double GridPoseGenerator::getZRot()
+std::vector<Eigen::Isometry3d> RandomZRotPoseGenerator::generate(const Eigen::Isometry3d &target_origin)
 {
-  return z_sampler(mt_rand);
+  auto poses = pg->generate(target_origin);
+  for (auto pose : poses)
+  {
+    pose.rotate(Eigen::AngleAxisd(z_sampler(mt_rand), Eigen::Vector3d::UnitZ()));
+  }
+  return poses;
 }
 
 } // namespace test

--- a/rct_optimizations/test/src/pose_generator.cpp
+++ b/rct_optimizations/test/src/pose_generator.cpp
@@ -121,6 +121,7 @@ std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Isometry
   return camera_positions;
 }
 
+// random Z+
 std::vector<Eigen::Isometry3d> RandomZRotPoseGenerator::generate(const Eigen::Isometry3d &target_origin)
 {
   auto poses = pg->generate(target_origin);

--- a/rct_optimizations/test/src/pose_generator.cpp
+++ b/rct_optimizations/test/src/pose_generator.cpp
@@ -22,7 +22,7 @@ Eigen::Isometry3d lookAt(const Eigen::Vector3d &origin,
 }
 
 // hemisphere
-std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Isometry3d &target_origin) const
+std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Isometry3d &target_origin)
 {
   std::size_t position_cnt = theta_cnt * phi_cnt;
 
@@ -53,7 +53,7 @@ std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Is
       // x is 'up' in target frame
       Eigen::Isometry3d camera_oriented = target_offset
                                         * lookAt(camera.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
-                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
+                                        * Eigen::Isometry3d(Eigen::AngleAxisd(getZRot(), Eigen::Vector3d::UnitZ()));
 
       // this vector is still in target spatial coordinates
       camera_positions.push_back(camera_oriented);
@@ -63,8 +63,13 @@ std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Is
   return camera_positions;
 }
 
+double HemispherePoseGenerator::getZRot()
+{
+  return z_sampler(mt_rand);
+}
+
 // cone
-std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Isometry3d &target_origin) const
+std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Isometry3d &target_origin)
 {
   std::vector<Eigen::Isometry3d> camera_positions;
   camera_positions.reserve(n_poses);
@@ -82,7 +87,7 @@ std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Isome
     // change orientation to look at target
     Eigen::Isometry3d camera_oriented = target_offset
                                       * lookAt(camera_pose.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
-                                      * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
+                                      * Eigen::Isometry3d(Eigen::AngleAxisd(getZRot(), Eigen::Vector3d::UnitZ()));
 
     camera_positions.push_back(camera_oriented);
   }
@@ -90,8 +95,13 @@ std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Isome
   return camera_positions;
 }
 
+double ConicalPoseGenerator::getZRot()
+{
+  return z_sampler(mt_rand);
+}
+
 // grid
-std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Isometry3d &target_origin) const
+std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Isometry3d &target_origin)
 {
   // Generates positions in target frame; need to convert to world frame
   std::vector<Eigen::Isometry3d> camera_positions;
@@ -111,13 +121,18 @@ std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Isometry
       // change orientation to look at target
       Eigen::Isometry3d camera_oriented = target_offset
                                         * lookAt(camera_pose.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
-                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
+                                        * Eigen::Isometry3d(Eigen::AngleAxisd(getZRot(), Eigen::Vector3d::UnitZ()));
 
       camera_positions.push_back(camera_oriented);
     }
   }
 
   return camera_positions;
+}
+
+double GridPoseGenerator::getZRot()
+{
+  return z_sampler(mt_rand);
 }
 
 } // namespace test

--- a/rct_optimizations/test/src/pose_generator.cpp
+++ b/rct_optimizations/test/src/pose_generator.cpp
@@ -22,7 +22,7 @@ Eigen::Isometry3d lookAt(const Eigen::Vector3d &origin,
 }
 
 // hemisphere
-std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Vector3d &target_origin) const
+std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Isometry3d &target_origin) const
 {
   std::size_t position_cnt = theta_cnt * phi_cnt;
 
@@ -41,8 +41,7 @@ std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Ve
       double phi_cur = phi_range(phi_it);
 
       // position in target coordinate frame
-      Eigen::Isometry3d camera = Eigen::Isometry3d::Identity();
-      camera.translation() = target_origin;
+      Eigen::Isometry3d camera = target_origin;
 
       Eigen::Vector3d position;
       position(0) = r * std::cos(theta_cur) * std::sin(phi_cur);
@@ -53,7 +52,7 @@ std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Ve
 
       // x is 'up' in target frame
       Eigen::Isometry3d camera_oriented = target_offset
-                                        * lookAt(camera.translation(), target_origin, Eigen::Vector3d(1, 0, 0))
+                                        * lookAt(camera.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
                                         * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
 
       // this vector is still in target spatial coordinates
@@ -65,7 +64,7 @@ std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Ve
 }
 
 // cone
-std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Vector3d &target_origin) const
+std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Isometry3d &target_origin) const
 {
   std::vector<Eigen::Isometry3d> camera_positions;
   camera_positions.reserve(n_poses);
@@ -75,15 +74,14 @@ std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Vecto
 
   for (unsigned i = 0; i < n_poses; ++i)
   {
-    Eigen::Isometry3d camera_pose = Eigen::Isometry3d::Identity();
-    camera_pose.translation() = target_origin;
+    Eigen::Isometry3d camera_pose = target_origin;
 
     // preserving target spatial coordinate frame:
     camera_pose.translate(Eigen::Vector3d{ r * cos(i * dt), r * sin(i * dt), h });
 
     // change orientation to look at target
     Eigen::Isometry3d camera_oriented = target_offset
-                                      * lookAt(camera_pose.translation(), target_origin, Eigen::Vector3d(1, 0, 0))
+                                      * lookAt(camera_pose.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
                                       * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
 
     camera_positions.push_back(camera_oriented);
@@ -93,7 +91,7 @@ std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Vecto
 }
 
 // grid
-std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Vector3d &target_origin) const
+std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Isometry3d &target_origin) const
 {
   // Generates positions in target frame; need to convert to world frame
   std::vector<Eigen::Isometry3d> camera_positions;
@@ -107,13 +105,12 @@ std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Vector3d
   {
     for (std::size_t j = 0; j < grid_side; ++j)
     {
-      Eigen::Isometry3d camera_pose = Eigen::Isometry3d::Identity();
-      camera_pose.translation()  = target_origin;
+      Eigen::Isometry3d camera_pose = target_origin;
       camera_pose.translate(Eigen::Vector3d{grid_coords(i), grid_coords(j), h });
 
       // change orientation to look at target
       Eigen::Isometry3d camera_oriented = target_offset
-                                        * lookAt(camera_pose.translation(), target_origin, Eigen::Vector3d(1, 0, 0))
+                                        * lookAt(camera_pose.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
                                         * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
 
       camera_positions.push_back(camera_oriented);

--- a/rct_optimizations/test/src/pose_generator.cpp
+++ b/rct_optimizations/test/src/pose_generator.cpp
@@ -52,7 +52,9 @@ std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Ve
       camera.translate(position);
 
       // x is 'up' in target frame
-      Eigen::Isometry3d camera_oriented = lookAt(camera.translation(), target_origin, Eigen::Vector3d(1, 0, 0));
+      Eigen::Isometry3d camera_oriented = target_offset
+                                        * lookAt(camera.translation(), target_origin, Eigen::Vector3d(1, 0, 0))
+                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
 
       // this vector is still in target spatial coordinates
       camera_positions.push_back(camera_oriented);
@@ -80,9 +82,9 @@ std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Vecto
     camera_pose.translate(Eigen::Vector3d{ r * cos(i * dt), r * sin(i * dt), h });
 
     // change orientation to look at target
-    Eigen::Isometry3d camera_oriented = lookAt(camera_pose.translation(),
-                                               target_origin,
-                                               Eigen::Vector3d(1, 0, 0));
+    Eigen::Isometry3d camera_oriented = target_offset
+                                      * lookAt(camera_pose.translation(), target_origin, Eigen::Vector3d(1, 0, 0))
+                                      * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
 
     camera_positions.push_back(camera_oriented);
   }
@@ -110,9 +112,9 @@ std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Vector3d
       camera_pose.translate(Eigen::Vector3d{grid_coords(i), grid_coords(j), h });
 
       // change orientation to look at target
-      Eigen::Isometry3d camera_oriented = lookAt(camera_pose.translation(),
-                                                 target_origin,
-                                                 Eigen::Vector3d(1, 0, 0));
+      Eigen::Isometry3d camera_oriented = target_offset
+                                        * lookAt(camera_pose.translation(), target_origin, Eigen::Vector3d(1, 0, 0))
+                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
 
       camera_positions.push_back(camera_oriented);
     }

--- a/rct_optimizations/test/src/pose_generator.cpp
+++ b/rct_optimizations/test/src/pose_generator.cpp
@@ -53,7 +53,7 @@ std::vector<Eigen::Isometry3d> HemispherePoseGenerator::generate(const Eigen::Is
       // x is 'up' in target frame
       Eigen::Isometry3d camera_oriented = target_offset
                                         * lookAt(camera.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
-                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_sampler(mt_rand), Eigen::Vector3d::UnitZ()));
+                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
 
       // this vector is still in target spatial coordinates
       camera_positions.push_back(camera_oriented);
@@ -83,7 +83,7 @@ std::vector<Eigen::Isometry3d> ConicalPoseGenerator::generate(const Eigen::Isome
     // change orientation to look at target
     Eigen::Isometry3d camera_oriented = target_offset
                                       * lookAt(camera_pose.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
-                                      * Eigen::Isometry3d(Eigen::AngleAxisd(z_sampler(mt_rand), Eigen::Vector3d::UnitZ()));
+                                      * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
 
     camera_positions.push_back(camera_oriented);
   }
@@ -112,7 +112,7 @@ std::vector<Eigen::Isometry3d> GridPoseGenerator::generate(const Eigen::Isometry
       // change orientation to look at target
       Eigen::Isometry3d camera_oriented = target_offset
                                         * lookAt(camera_pose.translation(), target_origin.translation(), Eigen::Vector3d(1, 0, 0))
-                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_sampler(mt_rand), Eigen::Vector3d::UnitZ()));
+                                        * Eigen::Isometry3d(Eigen::AngleAxisd(z_rot, Eigen::Vector3d::UnitZ()));
 
       camera_positions.push_back(camera_oriented);
     }


### PR DESCRIPTION
- Add new parameters to `PoseGenerator` implementations for rotation around camera Z-axis and transform offset relative to target origin.
- Allow multiple `PoseGenerator`s to be used to create observations when setting up a given test case.
- Pass around `SharedPtr`s to `PoseGenerator`s (needed to handle collections of `PoseGenerator`s, since the base class is abstract).
