### PR TITLE
Return CovarianceResult struct instead of raw Eigen matrix

### DIFF
--- a/rct_examples/src/tools/camera_on_wrist_extrinsic.cpp
+++ b/rct_examples/src/tools/camera_on_wrist_extrinsic.cpp
@@ -154,10 +154,7 @@ int main(int argc, char** argv)
   rct_ros_tools::printTransform(t, "Base", "Target", "BASE TO TARGET");
   rct_ros_tools::printNewLine();
 
-  std::cout << "Covariance (wrist to camera):\n" << opt_result.covariance_camera_mount_to_camera.matrix() << std::endl;
-  std::cout << "Covariance (base to target):\n" << opt_result.covariance_target_mount_to_target.matrix() << std::endl;
-  std::cout << "Covariance (w2c vs b2t):\n" << opt_result.covariance_tform_target_to_tform_camera.matrix() << std::endl;
-
+  std::cout << opt_result.covariance.toString() << std::endl;
 
   rct_ros_tools::printTitle("REPROJECTION ERROR");
   for (std::size_t i = 0; i < data_set.images.size(); ++i)

--- a/rct_examples/src/tools/intrinsic_calibration.cpp
+++ b/rct_examples/src/tools/intrinsic_calibration.cpp
@@ -140,7 +140,7 @@ int main(int argc, char** argv)
   rct_ros_tools::printCameraDistortion(new_dist, "RCT Distortion");
   rct_ros_tools::printNewLine();
 
-  std::cout << "Covariance (intrinsic):\n" << opt_result.covariance_intr.matrix() << std::endl;
+  std::cout << opt_result.covariance.toString() << std::endl;
 
   // Also try the OpenCV cameraCalibrate function
   rct_ros_tools::printTitle("OpenCV Calibration");

--- a/rct_optimizations/include/rct_optimizations/circle_fit.h
+++ b/rct_optimizations/include/rct_optimizations/circle_fit.h
@@ -3,9 +3,66 @@
 #include <vector>
 #include <Eigen/Dense>
 #include <rct_optimizations/types.h>
+#include <rct_optimizations/covariance_types.h>
 
 namespace rct_optimizations
 {
+
+/**
+ * @brief Cost function for the error between a point and a circle.
+ */
+class CircleDistCost
+{
+public:
+  CircleDistCost(const double& x, const double& y)
+    : x_(x), y_(y)
+  {}
+
+
+  /**
+   * @brief One formulation of a residual function for error relative to the center of a circle.
+   * Presented to the solver as three size-1 double parameters.
+   * @param sample A double pointer which contains {x, y, r_sqrt}.
+   */
+  template<typename T>
+  bool operator()(const T* const sample,
+                  T* residual) const
+  {
+    T r = sample[2] * sample[2];
+
+    T x_pos = x_ - sample[0];
+    T y_pos = y_ - sample[1];
+
+    residual[0] = r * r - x_pos * x_pos - y_pos * y_pos;
+    return true;
+  }
+
+  /**
+   * @brief An alternative formulation of a residual function for error relative to the center of a circle.
+   * Here, the inputs (x, y, r_sqrt) are provided as separate parameters. This is mathematically identical to the previous version,
+   * but the number and size of the parameters are presented differently to the solver (one size-3 double parameter).
+   * @param x_sample The x-coordinate of the center of the circle.
+   * @param y_sample The y-coordinate of the center of the circle.
+   * @param r_sqrt_sample The square root of the radius of the circle.
+   */
+  template<typename T>
+  bool operator()(const T* const x_sample,
+                  const T* const y_sample,
+                  const T* const r_sqrt_sample,
+                  T* residual) const
+  {
+    T r = r_sqrt_sample[0] * r_sqrt_sample[0];  // Using sqrt(radius) prevents the radius from ending up negative and improves numerical stability.
+
+    T x_pos = x_ - x_sample[0];
+    T y_pos = y_ - y_sample[0];
+
+    residual[0] = r * r - x_pos * x_pos - y_pos * y_pos;
+    return true;
+  }
+
+private:
+  double x_, y_;
+};
 
 /**
  * @brief Problem setup info for the circle fit optimization.
@@ -31,6 +88,8 @@ struct CircleFitProblem
    * @brief Estimate for the initial radius of the circle.
    */
   double radius_initial;
+
+  const std::vector<std::string> labels = {"x", "y", "r"};
 };
 
 /**
@@ -56,7 +115,7 @@ struct CircleFitResult
   /**
    * @brief The covariance matrix for the problem. A square 3x3 matrix giving covariance between each pair of elements. Order of elements is [x, y, radius].
    */
-  Eigen::MatrixXd covariance;
+  CovarianceResult covariance;
 
   /**
    * @brief Calculated circle center x-coord.

--- a/rct_optimizations/include/rct_optimizations/covariance_analysis.h
+++ b/rct_optimizations/include/rct_optimizations/covariance_analysis.h
@@ -62,14 +62,14 @@ CovarianceResult computeCovariance(ceres::Problem &problem,
 /**
  * @brief Compute covariance results for specified parameter blocks in a Ceres optimization problem and label them with the provided names.
  * @param problem The Ceres problem (after optimization).
- * @param parameter_blocks Specific parameter blocks to compute covariance between.
+ * @param parameter_blocks Specific parameter blocks for which covariance will be calculated.
  * @param parameter_names Labels for optimization parameters in the specified blocks.
  * @param options ceres::Covariance::Options to use when calculating covariance.
  * @return CovarianceResult for the problem.
  * @throw CovarianceException if covariance.Compute fails.
  * @throw CovarianceException if covariance.GetCovarianceMatrix fails.
  * @throw CovarianceException if parameter_names.size() != parameter_blocks.size().
- * @throw CovarianceException if the number of parameter label strings for a block is different than the number of parameters in that block.
+ * @throw CovarianceException if the number of parameter label strings provided for a block is different than the number of parameters in that block.
  */
 CovarianceResult computeCovariance(ceres::Problem &problem,
                                    const std::vector<const double *>& parameter_blocks,

--- a/rct_optimizations/include/rct_optimizations/covariance_analysis.h
+++ b/rct_optimizations/include/rct_optimizations/covariance_analysis.h
@@ -3,6 +3,7 @@
 #include <ceres/ceres.h>
 #include <Eigen/Dense>
 #include <iostream>
+#include <rct_optimizations/covariance_types.h>
 #include <rct_optimizations/types.h>
 
 namespace rct_optimizations
@@ -20,181 +21,58 @@ struct DefaultCovarianceOptions : ceres::Covariance::Options
 };
 
 /**
- * @brief Given a double array of Ceres covariance results, calculate standard deviations and correlation coefficients and format as an Eigen MatrixXd.
- * Each diagonal element is the standard deviation of a parameter, and its units match the units of that parameter.
- * Each off-diagonal element is the correlation coefficient of a pair of parameters, which is unitless and in the range [-1, 1].
- * @param cov Points to a double array containing covariance results from Ceres.
- * @param num_vars Number of elements in @ref cov.
- * @return A square matrix with size (num_vars x num_vars) containing standard deviations (diagonal elements) and correlation coefficients (off-diagonal elements).
- * Given that @ref cov contains the covariance matrix for parameter block A with parameters [a_1 ... a_n] where n = num_vars,
- * the output matrix will be arranged like this:
- *    |a_1|a_2|...|a_n
- * ---|---------------
- * a_1|
- * a_2|
- * ...|
- * a_n|
+ * @brief Given a covariance matrix, calculate the matrix of standard deviations and correlation coefficients.
+ * @param Covariance matrix
+ * @return Matrix of standard deviations (diagonal elements) and correlation coefficents (off-diagonal elements).
+ * @throw CovarianceException if @ref covariance_matrix is not square.
  */
-Eigen::MatrixXd covToEigenCorr(const double* cov, const std::size_t num_vars);
+Eigen::MatrixXd computeCorrelationsFromCovariance(const Eigen::MatrixXd& covariance_matrix);
 
 /**
- * @brief Arrange the Ceres covariance results as an Eigen matrix.
- * @param cov Points to a double array containing covariance results from Ceres.
- * @param num_vars Number of elements in @ref cov.
- * @return A square matrix with size (num_vars x num_vars) containing variance (diagonal elements) and covariance (off-diagonal elements).
- * Given that @ref cov contains the covariance matrix for parameter block A with parameters [a_1 ... a_n] where n = num_vars,
- * the output matrix will be arranged like this:
- *    |a_1|a_2|...|a_n
- * ---|---------------
- * a_1|
- * a_2|
- * ...|
- * a_n|
- */
-Eigen::MatrixXd covToEigenCov(const double* cov, const std::size_t num_vars);
-
-
-/**
- * @brief Calculate the off-diagonal correlation matrix given Ceres covariances.
- * @param cov_d1d1 Pointer to a double array containing covariance for the first parameter block.
- * @param num_vars1 Number of elements in cov_d1d1
- * @param cov_d2d2 Pointer to a double array containing covariance for the second parameter block.
- * @param num_vars2 Number of elements in cov_d1d2
- * @param cov_d1d2 Pointer to a double array containing correlation coefficients for the first parameter block relative to the second parameter block.
- * Must contain (num_vars1 x num_vars2 elements).
- * @return A matrix with size (num_vars1 x num_vars2) containing the off-diagonal covariance.
- * Each row corresponds to a parameter in the first block, and each column corresponds to a parameter in the second block.
- * Given that @ref cov_d1d1 contains the covariance matrix for parameter block A with parameters [a_1, a_2 ... a_n1] where n1 = num_vars1,
- * and that @ref cov_d2d2 contains the covariance matrix for parameter block B with parameters [b_1, b_2 ... b_n2] where n2 = num_vars2,
- * the output matrix will be arranged like this:
- *     |b_1|b_2|...|b_n2
- * ----|---------------
- * a_1 |
- * a_2 |
- * ... |
- * a_n1|
- */
-Eigen::MatrixXd covToEigenOffDiagCorr(const double* cov_d1d1, const std::size_t num_vars1, const double* cov_d2d2, const std::size_t num_vars2, const double* cov_d1d2);
-
-/**
- * @brief Compute variance and covariance for a given problem and Pose6d parameter. Uses @ref computeDVCovariance.
- * @param The Ceres problem (after optimization).
- * @param pose Pose6d parameter
- * @param options Options to use when calculating covariance. Use default if not explicitly set by user.
- * @return A square matrix with size (6 x 6) containing variance (diagonal elements) and covariance (off-diagonal elements).
- * Given that @ref pose contains the parameters [x, y, z, rx, ry, rz], the output matrix will be arranged like this:
- *   |x|y|z|rx|ry|rz
- * --|--------------
- * x |
- * y |
- * z |
- * rx|
- * ry|
- * rz|
- * @throw CovarianceException if computation of covariance fails for any pair of parameter blocks, or if GetCovarianceBlock returns false.
- */
-Eigen::MatrixXd computePoseCovariance(ceres::Problem& problem, const Pose6d& pose, const ceres::Covariance::Options& options = DefaultCovarianceOptions());
-
-/**
- * @brief Compute off-diagonal covariance between a Pose6d parameter and a double array parameter. Uses @ref computeDV2DVCovariance.
- * @param The Ceres problem (after optimization).
- * @param pose First Pose6d parameter.
- * @param dptr Second double array parameter.
- * @param num_vars Number of elements in dptr.
- * @param options Options to use when calculating covariance. Use default if not explicitly set by user.
- * @return A matrix with size (6 x num_vars) containing the off-diagonal covariance.
- * Each row corresponds to one of the six parameters in the Pose6d parameter block, and each column corresponds to a parameter in the second parameter block.
- * Given that @ref pose contains the parameters [x, y, z, rx, ry, rz], and that @ref dptr contains the parameters [a_1 ... a_n] where n = num_vars,
- * the output matrix will be arranged like this:
- *   |a_1|a_2|...|a_n
- * --|---------------
- * x |
- * y |
- * z |
- * rx|
- * ry|
- * rz|
- * @throw CovarianceException if computation of covariance fails for any pair of parameter blocks, or if GetCovarianceBlock returns false.
- */
-Eigen::MatrixXd computePose2DVCovariance(ceres::Problem &problem, const Pose6d &pose, const double* dptr, const std::size_t num_vars, const ceres::Covariance::Options& options = DefaultCovarianceOptions());
-
-/**
- * @brief Compute off-diagonal covariance between two Pose6d parameters. Uses @ref computeDV2DVCovariance.
- * @param The Ceres problem (after optimization).
- * @param p1 First pose parameter block.
- * @param p2 Second pose parameter block.
- * @param options Options to use when calculating covariance. Use default if not explicitly set by user.
- * @return A square matrix with size (6 x 6) containing the off-diagonal covariance.
- * The matrix rows correspond to the parameters in the first Pose6d parameter block, and the matrix columns correspond to the parameters in the second Pose6d parameter block.
- * Given that @ref p1 contains the parameters [x1, y1, z1, rx1, ry1, rz1] and @ref p2 contains the parameters [x2, y2, z2, rx2, ry2, rz2],
- * the output matrix will be arranged like this:
- *    |x2|y2|z2|rx2|ry2|rz2
- * ---|--------------------
- * x1 |
- * y1 |
- * z1 |
- * rx1|
- * ry1|
- * rz1|
- * @throw CovarianceException if computation of covariance fails for any pair of parameter blocks, or if GetCovarianceBlock returns false.
- */
-Eigen::MatrixXd computePose2PoseCovariance(ceres::Problem &problem, const Pose6d &p1, const Pose6d &p2, const ceres::Covariance::Options& options = DefaultCovarianceOptions());
-
-/**
- * @brief Compute standard deviations and correlation coefficients for a given problem and parameter block. Uses @ref computeDV2DVCovariance.
+ * @brief Compute all covariance results for a Ceres optimization problem. Labels results with generic names.
  * @param problem The Ceres problem (after optimization).
- * @param dptr Ceres parameter block.
- * @param num_vars Number of parameters in @ref dptr.
- * @param options Options to use when calculating covariance. Use default if not explicitly set by user.
- * @return A square matrix with size (num_vars x num_vars) containing standard deviations (diagonal elements) and correlation coefficients (off-diagonal elements).
- * Given that @ref dptr contains the parameters [a_1 ... a_n] where n = num_vars, the output matrix will be arranged like this:
- *    |a_1|a_2|...|a_n
- * ---|---------------
- * a_1|
- * a_2|
- * ...|
- * a_n|
- * @throw CovarianceException if computation of covariance fails for any pair of parameter blocks, or if GetCovarianceBlock returns false.
+ * @param options ceres::Covariance::Options to use when calculating covariance.
+ * @return CovarianceResult for the problem.
  */
-Eigen::MatrixXd computeDVCovariance(ceres::Problem &problem, const double* dptr, const std::size_t& num_vars, const ceres::Covariance::Options& options = DefaultCovarianceOptions());
+CovarianceResult computeCovariance(ceres::Problem &problem,
+                                   const ceres::Covariance::Options& options = DefaultCovarianceOptions());
 
 /**
- * @brief Compute off-diagonal covariance for a given problem and parameters.
+ * @brief Compute covariance results for the specified parameter blocks in a Ceres optimization problem. Labels results with generic names.
  * @param problem The Ceres problem (after optimization).
- * @param dptr1 First parameter block.
- * @param num_vars1 Number of parameters in @ref dptr1.
- * @param dptr2 Second parameter block.
- * @param num_vars2 Number of parameters in @ref dptr2.
- * @return A matrix with size (num_vars1 x num_vars2) containing the off-diagonal covariance.
- * Given that @ref dptr1 contains the parameters [a_1, a_2 ... a_n1] where n1 = num_vars1 and @ref dptr2 contains the parameters [b_1, b_2 ... b_n2] where n2 = num_vars2,
- * the output matrix will be arranged like this:
- *     |b_1|b_2|...|b_n2
- * ----|----------------
- * a_1 |
- * a_2 |
- * ... |
- * a_n1|
- * @throw CovarianceException if computation of covariance fails for any pair of parameter blocks, or if GetCovarianceBlock returns false.
+ * @param parameter_blocks Specific parameter blocks to compute covariance between.
+ * @param options ceres::Covariance::Options to use when calculating covariance.
+ * @return CovarianceResult for the problem.
  */
-Eigen::MatrixXd computeDV2DVCovariance(ceres::Problem &problem, const double* dptr1, const std::size_t num_vars1, const double* dptr2, const std::size_t num_vars2, const ceres::Covariance::Options& options = DefaultCovarianceOptions());
+CovarianceResult computeCovariance(ceres::Problem &problem,
+                                   const std::vector<const double *>& parameter_blocks,
+                                   const ceres::Covariance::Options& options = DefaultCovarianceOptions());
 
 /**
- * @brief Compute variance and covariance for a given problem and parameters. Uses @ref computeDVCovariance and @ref computeDV2DVCovariance.
- * @param The Ceres problem (after optimization).
- * @param dptr1 First parameter block
- * @param num_vars1 Number of parameters in @ref dptr1
- * @param dptr2 Second parameter block
- * @param num_vars1 Number of parameters in @ref dptr2
- * @param options Options to use when calculating covariance. Use default if not explicitly set by user.
- * @return A square matrix with size (n x n), where n = num_vars1 + num_vars2, containing variance (diagonal elements) and covariance (off-diagonal elements).
- * With input parameter blocks p1 and p2, the output matrix will be arranged like this:
- *    |     p1    |     p2    |
- * ---|-----------|-----------|
- * p1 | C(p1, p1) | C(p1, p2) |
- * p2 | C(p2, p1) | C(p2, p2) |
+ * @brief Compute all covariance results for a Ceres optimization problem and label them with the provided names.
+ * @param problem The Ceres problem (after optimization).
+ * @param parameter_names Labels for all optimization parameters in the problem.
+ * @param options ceres::Covariance::Options to use when calculating covariance.
+ * @return CovarianceResult for the problem.
  */
-Eigen::MatrixXd computeFullDV2DVCovariance(ceres::Problem& problem, const double* dptr1, const std::size_t num_vars1, const double* dptr2, const std::size_t num_vars2,
-                                           const ceres::Covariance::Options& options = DefaultCovarianceOptions());
+CovarianceResult computeCovariance(ceres::Problem &problem,
+                                   const std::vector<std::vector<std::string>>& parameter_names,
+                                   const ceres::Covariance::Options& options = DefaultCovarianceOptions());
 
-
+/**
+ * @brief Compute covariance results for specified parameter blocks in a Ceres optimization problem and label them with the provided names.
+ * @param problem The Ceres problem (after optimization).
+ * @param parameter_blocks Specific parameter blocks to compute covariance between.
+ * @param parameter_names Labels for optimization parameters in the specified blocks.
+ * @param options ceres::Covariance::Options to use when calculating covariance.
+ * @return CovarianceResult for the problem.
+ * @throw CovarianceException if covariance.Compute fails.
+ * @throw CovarianceException if covariance.GetCovarianceMatrix fails.
+ * @throw CovarianceException if parameter_names.size() != parameter_blocks.size().
+ * @throw CovarianceException if the number of parameter label strings for a block is different than the number of parameters in that block.
+ */
+CovarianceResult computeCovariance(ceres::Problem &problem,
+                                   const std::vector<const double *>& parameter_blocks,
+                                   const std::vector<std::vector<std::string>>& parameter_names,
+                                   const ceres::Covariance::Options& options = DefaultCovarianceOptions());
 }  // namespace rct_optimizations

--- a/rct_optimizations/include/rct_optimizations/covariance_types.h
+++ b/rct_optimizations/include/rct_optimizations/covariance_types.h
@@ -58,7 +58,7 @@ struct CovarianceResult
     std::vector<NamedParam> out;
     for (auto corr : correlation_coeffs)
     {
-      if (abs(corr.value) > threshold)
+      if (std::abs(corr.value) > threshold)
         out.push_back(corr);
     }
     return out;

--- a/rct_optimizations/include/rct_optimizations/covariance_types.h
+++ b/rct_optimizations/include/rct_optimizations/covariance_types.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include <cmath>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace rct_optimizations
+{
+/** @brief A double value identified by one or two name strings. */
+struct NamedParam
+{
+  /** @brief Pair of names identifying this parameter. For types with just one name (e.g. standard deviation), only names.first is used. */
+  std::pair<std::string, std::string> names;
+  /** @brief Value of this parameter. */
+  std::double_t value;
+
+  /**
+   * @brief Format the NamedParam as a string.
+   * @return
+   */
+  std::string toString() const
+  {
+    std::stringbuf buf;
+    std::ostream os(&buf);
+    os << names.first.c_str() << " " << names.second.c_str() << " " << value;;
+    return buf.str();
+  }
+};
+
+/**
+ * @brief Covariance results for optimization parameters.
+ * Contains standard deviations, covariances, and correlation coefficients, as well as the original covariance and correlation matrices.
+ */
+struct CovarianceResult
+{
+  /** @brief standard deviations */
+  std::vector<NamedParam> standard_deviations;
+  /** @brief correlation_coeffs */
+  std::vector<NamedParam> correlation_coeffs;
+  /** @brief covariances */
+  std::vector<NamedParam> covariances;
+  /** @brief Covariance matrix output from Ceres */
+  Eigen::MatrixXd covariance_matrix;
+  /** @brief Correlation matrix */
+  Eigen::MatrixXd correlation_matrix;
+
+  /**
+   * @brief Returns named correlation coefficients that exceed @ref threshold.
+   * @param Magnitude of a correlation coefficient that will result in it being returned.
+   * @return Vector of NamedParams for correlation coefficients above @ref threshold.
+   */
+  std::vector<NamedParam> getCorrelationCoeffOutsideThreshold(const std::double_t& threshold) const
+  {
+    std::vector<NamedParam> out;
+    for (auto corr : correlation_coeffs)
+    {
+      if (abs(corr.value) > threshold)
+        out.push_back(corr);
+    }
+    return out;
+  }
+
+  /**
+   * @brief Format NamedParam contents as a string.
+   * @return
+   */
+  std::string toString() const
+  {
+    std::string out;
+    out.append("Std. Devs.\n");
+    for (auto std_dev : standard_deviations)
+    {
+      out.append(std_dev.toString() + "\n");
+    }
+
+    out.append("\nCovariance\n");
+    for (auto cov : covariances)
+    {
+      out.append(cov.toString() + "\n");
+    }
+
+    out.append("\nCorrelation Coeffs.\n");
+    for (auto corr : correlation_coeffs)
+    {
+      out.append(corr.toString() + "\n");
+    }
+    return out;
+  }
+
+  /**
+   * @brief Compose a string with a list of NamedParams for correlation coefficeints above @ref threshold.
+   * @param threshold
+   * @return
+   */
+  std::string printCorrelationCoeffAboveThreshold(const std::double_t& threshold) const
+  {
+    auto above_thresh = getCorrelationCoeffOutsideThreshold(threshold);
+
+    if (above_thresh.size() == 0)
+    {
+      return std::string("No correlation coefficients with magnitude > " + std::to_string(threshold) + "\n");
+    }
+
+    std::string out("\nCorrelation Coeff. > " + std::to_string(threshold) + ":\n");
+    for (auto corr : above_thresh)
+    {
+      out.append(corr.toString());
+    }
+    return out;
+  }
+};
+}  // namespace rct_optimizations

--- a/rct_optimizations/include/rct_optimizations/covariance_types.h
+++ b/rct_optimizations/include/rct_optimizations/covariance_types.h
@@ -108,7 +108,7 @@ struct CovarianceResult
     std::string out("\nCorrelation Coeff. > " + std::to_string(threshold) + ":\n");
     for (auto corr : above_thresh)
     {
-      out.append(corr.toString());
+      out.append(corr.toString() + "\n");
     }
     return out;
   }

--- a/rct_optimizations/include/rct_optimizations/covariance_types.h
+++ b/rct_optimizations/include/rct_optimizations/covariance_types.h
@@ -93,7 +93,7 @@ struct CovarianceResult
   }
 
   /**
-   * @brief Compose a string with a list of NamedParams for correlation coefficeints above @ref threshold.
+   * @brief Compose a string with a list of NamedParams for correlation coefficients above @ref threshold.
    * @param threshold
    * @return
    */

--- a/rct_optimizations/include/rct_optimizations/covariance_types.h
+++ b/rct_optimizations/include/rct_optimizations/covariance_types.h
@@ -61,7 +61,7 @@ struct CovarianceResult
       if (std::abs(corr.value) > threshold)
         out.push_back(corr);
     }
-    std::sort(out.begin(), out.end(), [](NamedParam a, NamedParam b) { return a.value > b.value; });
+    std::sort(out.begin(), out.end(), [](NamedParam a, NamedParam b) { return std::abs(a.value) > std::abs(b.value); });
     return out;
   }
 

--- a/rct_optimizations/include/rct_optimizations/covariance_types.h
+++ b/rct_optimizations/include/rct_optimizations/covariance_types.h
@@ -25,10 +25,9 @@ struct NamedParam
    */
   std::string toString() const
   {
-    std::stringbuf buf;
-    std::ostream os(&buf);
-    os << names.first.c_str() << " " << names.second.c_str() << " " << value;;
-    return buf.str();
+    std::stringstream ss;
+    ss << names.first.c_str() << " " << names.second.c_str() << " " << value;
+    return ss.str();
   }
 };
 

--- a/rct_optimizations/include/rct_optimizations/covariance_types.h
+++ b/rct_optimizations/include/rct_optimizations/covariance_types.h
@@ -2,6 +2,7 @@
 
 #include <Eigen/Dense>
 
+#include <algorithm>
 #include <cmath>
 #include <ostream>
 #include <sstream>
@@ -61,6 +62,7 @@ struct CovarianceResult
       if (std::abs(corr.value) > threshold)
         out.push_back(corr);
     }
+    std::sort(out.begin(), out.end(), [](NamedParam a, NamedParam b) { return a.value > b.value; });
     return out;
   }
 

--- a/rct_optimizations/include/rct_optimizations/dh_chain.h
+++ b/rct_optimizations/include/rct_optimizations/dh_chain.h
@@ -38,6 +38,8 @@ struct DHTransform
 {
   DHTransform(const Eigen::Vector4d& params_, DHJointType type_);
 
+  DHTransform(const Eigen::Vector4d& params_, DHJointType type_, const std::string& name_);
+
   /**
    * @brief Creates the homogoneous transformation from the previous link to the current link
    * @param joint_value - The joint value to apply when caluclating the transform
@@ -90,6 +92,8 @@ struct DHTransform
 
   double createRandomJointValue() const;
 
+  std::array<std::string, 4> getParamLabels() const;
+
   /** @brief DH parameters
    *  d: The linear offset in Z
    *  theta: The rotational offset about Z
@@ -100,6 +104,7 @@ struct DHTransform
   DHJointType type; /** @brief The type of actuation of the joint */
   double max = M_PI; /** @brief Joint max */
   double min = -M_PI; /** @brief Joint min */
+  std::string name; /** @brief Label for this transform */
 };
 
 /**
@@ -170,6 +175,8 @@ public:
    * @return
    */
   std::vector<DHJointType> getJointTypes() const;
+
+  std::vector<std::array<std::string, 4>> getParamLabels() const;
 
 protected:
   /** @brief The DH transforms that make up the chain */

--- a/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
+++ b/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
@@ -1,6 +1,7 @@
 #ifndef RCT_CAMERA_INTRINSIC_H
 #define RCT_CAMERA_INTRINSIC_H
 
+#include <rct_optimizations/covariance_types.h>
 #include "rct_optimizations/types.h"
 #include "boost/optional.hpp"
 
@@ -13,6 +14,10 @@ struct IntrinsicEstimationProblem
   CameraIntrinsics intrinsics_guess;
   bool use_extrinsic_guesses;
   std::vector<Eigen::Isometry3d> extrinsic_guesses;
+
+  std::string label_extr = "pose";
+  const std::array<std::string, 9> labels_intrinsic_params = {"fx", "fy", "cx", "cy", "k1", "k2", "p1", "p2", "k3"};
+  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
 };
 
 struct IntrinsicEstimationResult
@@ -26,7 +31,7 @@ struct IntrinsicEstimationResult
 
   std::vector<Eigen::Isometry3d> target_transforms;
 
-  Eigen::MatrixXd covariance_intr;
+  CovarianceResult covariance;
 };
 
 IntrinsicEstimationResult optimize(const IntrinsicEstimationProblem& params);

--- a/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
+++ b/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
@@ -16,8 +16,8 @@ struct IntrinsicEstimationProblem
   std::vector<Eigen::Isometry3d> extrinsic_guesses;
 
   std::string label_extr = "pose";
-  const std::array<std::string, 9> labels_intrinsic_params = {"fx", "fy", "cx", "cy", "k1", "k2", "p1", "p2", "k3"};
-  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+  const std::array<std::string, 9> labels_intrinsic_params = {{"fx", "fy", "cx", "cy", "k1", "k2", "p1", "p2", "k3"}};
+  const std::array<std::string, 6> labels_isometry3d = {{"x", "y", "z", "rx", "ry", "rz"}};
 };
 
 struct IntrinsicEstimationResult

--- a/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
+++ b/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
@@ -11,7 +11,6 @@ struct IntrinsicEstimationProblem
 {
   std::vector<Correspondence2D3D::Set> image_observations;
   CameraIntrinsics intrinsics_guess;
-
   bool use_extrinsic_guesses;
   std::vector<Eigen::Isometry3d> extrinsic_guesses;
 };

--- a/rct_optimizations/include/rct_optimizations/extrinsic_hand_eye.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_hand_eye.h
@@ -16,7 +16,8 @@
  */
 #pragma once
 
-#include "rct_optimizations/types.h"
+#include <rct_optimizations/covariance_types.h>
+#include <rct_optimizations/types.h>
 #include <Eigen/Dense>
 #include <vector>
 
@@ -28,6 +29,12 @@ struct ExtrinsicHandEyeProblem2D3D
   CameraIntrinsics intr;
   Eigen::Isometry3d target_mount_to_target_guess;
   Eigen::Isometry3d camera_mount_to_camera_guess;
+
+  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+
+  std::string label_target_mount_to_target = "wrist_to_target";
+
+  std::string label_camera_mount_to_camera = "base_to_camera";
 };
 
 struct ExtrinsicHandEyeProblem3D3D
@@ -35,6 +42,12 @@ struct ExtrinsicHandEyeProblem3D3D
   typename Observation3D3D::Set observations;
   Eigen::Isometry3d target_mount_to_target_guess;
   Eigen::Isometry3d camera_mount_to_camera_guess;
+
+  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+
+  std::string label_target_mount_to_target = "wrist_to_target";
+
+  std::string label_camera_mount_to_camera = "base_to_camera";
 };
 
 struct ExtrinsicHandEyeResult
@@ -46,9 +59,7 @@ struct ExtrinsicHandEyeResult
   Eigen::Isometry3d target_mount_to_target;
   Eigen::Isometry3d camera_mount_to_camera;
 
-  Eigen::MatrixXd covariance_target_mount_to_target;
-  Eigen::MatrixXd covariance_camera_mount_to_camera;
-  Eigen::MatrixXd covariance_tform_target_to_tform_camera;
+  CovarianceResult covariance;
 };
 
 ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D &params);

--- a/rct_optimizations/include/rct_optimizations/extrinsic_hand_eye.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_hand_eye.h
@@ -30,11 +30,11 @@ struct ExtrinsicHandEyeProblem2D3D
   Eigen::Isometry3d target_mount_to_target_guess;
   Eigen::Isometry3d camera_mount_to_camera_guess;
 
-  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+  const std::array<std::string, 6> labels_isometry3d = {{"x", "y", "z", "rx", "ry", "rz"}};
 
-  std::string label_target_mount_to_target = "wrist_to_target";
+  std::string label_target_mount_to_target = "target_mount_to_target";
 
-  std::string label_camera_mount_to_camera = "base_to_camera";
+  std::string label_camera_mount_to_camera = "camera_mount_to_camera";
 };
 
 struct ExtrinsicHandEyeProblem3D3D
@@ -43,11 +43,11 @@ struct ExtrinsicHandEyeProblem3D3D
   Eigen::Isometry3d target_mount_to_target_guess;
   Eigen::Isometry3d camera_mount_to_camera_guess;
 
-  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+  const std::array<std::string, 6> labels_isometry3d = {{"x", "y", "z", "rx", "ry", "rz"}};
 
-  std::string label_target_mount_to_target = "wrist_to_target";
+  std::string label_target_mount_to_target = "target_mount_to_target";
 
-  std::string label_camera_mount_to_camera = "base_to_camera";
+  std::string label_camera_mount_to_camera = "camera_mount_to_camera";
 };
 
 struct ExtrinsicHandEyeResult

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera.h
@@ -15,7 +15,8 @@
 #ifndef RCT_EXTRINSIC_MULTI_STATIC_CAMERA_H
 #define RCT_EXTRINSIC_MULTI_STATIC_CAMERA_H
 
-#include "rct_optimizations/types.h"
+#include <rct_optimizations/covariance_types.h>
+#include <rct_optimizations/types.h>
 #include <Eigen/Dense>
 #include <vector>
 
@@ -46,6 +47,14 @@ struct ExtrinsicMultiStaticCameraMovingTargetProblem
 
   /** @brief Your best guess at the "base frame" to "camera frame" transform; one for each camera */
   std::vector<Eigen::Isometry3d> base_to_camera_guess;
+
+  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+
+  std::string label_wrist_to_target = "wrist_to_target";
+
+  std::string label_base_to_camera = "base_to_camera";
+
+  std::vector<std::string> labels_image_observations;
 };
 
 struct ExtrinsicMultiStaticCameraMovingTargetResult
@@ -80,6 +89,8 @@ struct ExtrinsicMultiStaticCameraMovingTargetResult
    * @brief The final calibrated result of "base frame" to "camera optical frame".
    */
   std::vector<Eigen::Isometry3d> base_to_camera;
+
+  CovarianceResult covariance;
 };
 
 ExtrinsicMultiStaticCameraMovingTargetResult optimize(const ExtrinsicMultiStaticCameraMovingTargetProblem& params);

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera.h
@@ -48,7 +48,7 @@ struct ExtrinsicMultiStaticCameraMovingTargetProblem
   /** @brief Your best guess at the "base frame" to "camera frame" transform; one for each camera */
   std::vector<Eigen::Isometry3d> base_to_camera_guess;
 
-  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+  const std::array<std::string, 6> labels_isometry3d = {{"x", "y", "z", "rx", "ry", "rz"}};
 
   std::string label_wrist_to_target = "wrist_to_target";
 

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_only.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_only.h
@@ -15,7 +15,8 @@
 #ifndef RCT_EXTRINSIC_MULTI_STATIC_CAMERA_ONLY_H
 #define RCT_EXTRINSIC_MULTI_STATIC_CAMERA_ONLY_H
 
-#include "rct_optimizations/types.h"
+#include <rct_optimizations/covariance_types.h>
+#include <rct_optimizations/types.h>
 #include <Eigen/Dense>
 #include <vector>
 
@@ -48,6 +49,14 @@ struct ExtrinsicMultiStaticCameraOnlyProblem
 
   /** @brief Your best guess at the "base frame" to "camera frame" transform; one for each camera */
   std::vector<Eigen::Isometry3d> base_to_camera_guess;
+
+  std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+
+  std::string label_base_to_target = "base_to_target";
+
+  std::string label_base_to_camera = "base_to_camera";
+
+  std::vector<std::string> labels_image_observations;
 };
 
 struct ExtrinsicMultiStaticCameraOnlyResult
@@ -78,6 +87,8 @@ struct ExtrinsicMultiStaticCameraOnlyResult
 
   /** @brief The final calibrated result of "base frame" to "camera optical frame". */
   std::vector<Eigen::Isometry3d> base_to_camera;
+
+  CovarianceResult covariance;
 };
 
 ExtrinsicMultiStaticCameraOnlyResult optimize(const ExtrinsicMultiStaticCameraOnlyProblem& params);

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_only.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_only.h
@@ -50,7 +50,7 @@ struct ExtrinsicMultiStaticCameraOnlyProblem
   /** @brief Your best guess at the "base frame" to "camera frame" transform; one for each camera */
   std::vector<Eigen::Isometry3d> base_to_camera_guess;
 
-  std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+  std::array<std::string, 6> labels_isometry3d = {{"x", "y", "z", "rx", "ry", "rz"}};
 
   std::string label_base_to_target = "base_to_target";
 

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_wrist_only.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_wrist_only.h
@@ -51,7 +51,7 @@ struct ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem
     */
   std::vector<Eigen::Isometry3d> base_to_camera_guess;
 
-  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+  const std::array<std::string, 6> labels_isometry3d = {{"x", "y", "z", "rx", "ry", "rz"}};
 
   std::string label_wrist_to_target = "wrist_to_target";
 

--- a/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_wrist_only.h
+++ b/rct_optimizations/include/rct_optimizations/extrinsic_multi_static_camera_wrist_only.h
@@ -15,7 +15,8 @@
 #ifndef RCT_EXTRINSIC_MULTI_STATIC_CAMERA_WRIST_ONLY_H
 #define RCT_EXTRINSIC_MULTI_STATIC_CAMERA_WRIST_ONLY_H
 
-#include "rct_optimizations/types.h"
+#include <rct_optimizations/types.h>
+#include <rct_optimizations/covariance_types.h>
 #include <Eigen/Dense>
 #include <vector>
 
@@ -49,6 +50,14 @@ struct ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem
    * calibrating the set of cameras using a single transformation.
     */
   std::vector<Eigen::Isometry3d> base_to_camera_guess;
+
+  const std::array<std::string, 6> labels_isometry3d = {"x", "y", "z", "rx", "ry", "rz"};
+
+  std::string label_wrist_to_target = "wrist_to_target";
+
+  std::string label_base_to_camera = "base_to_camera";
+
+  std::vector<std::string> labels_image_observations;
 };
 
 struct ExtrinsicMultiStaticCameraMovingTargetWristOnlyResult
@@ -83,6 +92,8 @@ struct ExtrinsicMultiStaticCameraMovingTargetWristOnlyResult
    * @brief The final calibrated result of "base frame" to "camera optical frame".
    */
   std::vector<Eigen::Isometry3d> base_to_camera;
+
+  CovarianceResult covariance;
 };
 
 ExtrinsicMultiStaticCameraMovingTargetWristOnlyResult optimize(const ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem& params);

--- a/rct_optimizations/include/rct_optimizations/pnp.h
+++ b/rct_optimizations/include/rct_optimizations/pnp.h
@@ -15,8 +15,8 @@ struct PnPProblem
   Eigen::Isometry3d camera_to_target_guess;
 
   std::string label_camera_to_target_guess = "camera_to_target";
-  const std::array<std::string, 3> labels_translation = {"x", "y", "z"};
-  const std::array<std::string, 3> labels_rotation = {"rx", "ry", "rz"};
+  const std::array<std::string, 3> labels_translation = {{"x", "y", "z"}};
+  const std::array<std::string, 3> labels_rotation = {{"rx", "ry", "rz"}};
 
 };
 
@@ -27,8 +27,8 @@ struct PnPProblem3D
   Eigen::Isometry3d camera_to_target_guess;
 
   std::string label_camera_to_target_guess = "camera_to_target";
-  const std::array<std::string, 3> labels_translation = {"x", "y", "z"};
-  const std::array<std::string, 3> labels_rotation = {"rx", "ry", "rz"};
+  const std::array<std::string, 3> labels_translation = {{"x", "y", "z"}};
+  const std::array<std::string, 3> labels_rotation = {{"rx", "ry", "rz"}};
 };
 
 struct PnPResult

--- a/rct_optimizations/include/rct_optimizations/pnp.h
+++ b/rct_optimizations/include/rct_optimizations/pnp.h
@@ -1,6 +1,7 @@
 #ifndef RCT_PNP_H
 #define RCT_PNP_H
 
+#include <rct_optimizations/covariance_types.h>
 #include <rct_optimizations/types.h>
 
 namespace rct_optimizations
@@ -12,6 +13,10 @@ struct PnPProblem
   Correspondence2D3D::Set correspondences;
 
   Eigen::Isometry3d camera_to_target_guess;
+  std::string label_camera_to_target_guess = "camera_to_target";
+  const std::array<std::string, 3> labels_translation = {"x", "y", "z"};
+  const std::array<std::string, 3> labels_rotation = {"rx", "ry", "rz"};
+
 };
 
 struct PnPProblem3D
@@ -28,7 +33,8 @@ struct PnPResult
   double final_cost_per_obs;
 
   Eigen::Isometry3d camera_to_target;
-  Eigen::MatrixXd camera_to_target_covariance;
+
+  CovarianceResult covariance;
 };
 
 PnPResult optimize(const PnPProblem& params);

--- a/rct_optimizations/include/rct_optimizations/pnp.h
+++ b/rct_optimizations/include/rct_optimizations/pnp.h
@@ -13,6 +13,7 @@ struct PnPProblem
   Correspondence2D3D::Set correspondences;
 
   Eigen::Isometry3d camera_to_target_guess;
+
   std::string label_camera_to_target_guess = "camera_to_target";
   const std::array<std::string, 3> labels_translation = {"x", "y", "z"};
   const std::array<std::string, 3> labels_rotation = {"rx", "ry", "rz"};
@@ -24,6 +25,10 @@ struct PnPProblem3D
   Correspondence3D3D::Set correspondences;
 
   Eigen::Isometry3d camera_to_target_guess;
+
+  std::string label_camera_to_target_guess = "camera_to_target";
+  const std::array<std::string, 3> labels_translation = {"x", "y", "z"};
+  const std::array<std::string, 3> labels_rotation = {"rx", "ry", "rz"};
 };
 
 struct PnPResult

--- a/rct_optimizations/include/rct_optimizations/types.h
+++ b/rct_optimizations/include/rct_optimizations/types.h
@@ -144,7 +144,6 @@ using KinObservation2D3D = KinematicObservation<2, 3>;
 /** @brief Typedef for kinematic observations of 3D sensor to 3D target correspondences */
 using KinObservation3D3D = KinematicObservation<3, 3>;
 
-
 struct OptimizationException : public std::runtime_error
 {
 public:

--- a/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
+++ b/rct_optimizations/include/rct_optimizations/validation/camera_intrinsic_calibration_validation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <rct_optimizations/pnp.h>
+#include <rct_optimizations/covariance_types.h>
 #include <rct_optimizations/types.h>
 
 namespace rct_optimizations

--- a/rct_optimizations/src/rct_optimizations/camera_intrinsic.cpp
+++ b/rct_optimizations/src/rct_optimizations/camera_intrinsic.cpp
@@ -247,7 +247,7 @@ rct_optimizations::optimize(const rct_optimizations::IntrinsicEstimationProblem&
 
   // TODO: How to handle errors while calculating covariance? Possible for optimization to converge even though the covariance matrix is near rank deficient,
   // which means the result contains (potentially) valid optimization results but partial or invalid covariance results.
-  result.covariance_intr = rct_optimizations::computeDVCovariance(problem, internal_intrinsics_data.data(), 9);
+//  result.covariance_intr = rct_optimizations::computeDVCovariance(problem, internal_intrinsics_data.data(), 9);
 
   return result;
 }

--- a/rct_optimizations/src/rct_optimizations/camera_intrinsic.cpp
+++ b/rct_optimizations/src/rct_optimizations/camera_intrinsic.cpp
@@ -1,9 +1,9 @@
 #include "rct_optimizations/experimental/camera_intrinsic.h"
-#include <rct_optimizations/pnp.h>
 
 #include <rct_optimizations/ceres_math_utilities.h>
-#include <rct_optimizations/eigen_conversions.h>
 #include <rct_optimizations/covariance_analysis.h>
+#include <rct_optimizations/eigen_conversions.h>
+#include <rct_optimizations/pnp.h>
 
 #include <ceres/ceres.h>
 
@@ -221,6 +221,24 @@ rct_optimizations::optimize(const rct_optimizations::IntrinsicEstimationProblem&
     }
   }
 
+  std::vector<const double*> param_blocks;
+  std::vector<std::vector<std::string>> param_labels;
+
+  param_blocks.emplace_back(internal_intrinsics_data.data());
+  param_labels.emplace_back(params.labels_intrinsic_params.begin(), params.labels_intrinsic_params.end());
+
+  for (std::size_t i = 0; i < internal_poses.size(); i++)
+  {
+    param_blocks.emplace_back(internal_poses[i].values.data());
+    std::vector<std::string> labels;
+    // compose labels poseN_x, etc.
+    for (auto label_extr : params.labels_isometry3d)
+    {
+      labels.push_back(params.label_extr + std::to_string(i) + "_" + label_extr);
+    }
+    param_labels.push_back(labels);
+  }
+
   // Solve
   ceres::Solver::Options options;
   options.max_num_iterations = 1000;
@@ -245,9 +263,7 @@ rct_optimizations::optimize(const rct_optimizations::IntrinsicEstimationProblem&
   result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
   result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
 
-  // TODO: How to handle errors while calculating covariance? Possible for optimization to converge even though the covariance matrix is near rank deficient,
-  // which means the result contains (potentially) valid optimization results but partial or invalid covariance results.
-//  result.covariance_intr = rct_optimizations::computeDVCovariance(problem, internal_intrinsics_data.data(), 9);
+  result.covariance = rct_optimizations::computeCovariance(problem, param_blocks, param_labels);
 
   return result;
 }

--- a/rct_optimizations/src/rct_optimizations/circle_fit.cpp
+++ b/rct_optimizations/src/rct_optimizations/circle_fit.cpp
@@ -2,66 +2,6 @@
 #include <rct_optimizations/circle_fit.h>
 #include <rct_optimizations/covariance_analysis.h>
 
-namespace
-{
-
-/**
- * @brief Cost function for the error between a point and a circle.
- */
-class CircleDistCost
-{
-public:
-  CircleDistCost(const double& x, const double& y)
-    : x_(x), y_(y)
-  {}
-
-
-  /**
-   * @brief One formulation of a residual function for error relative to the center of a circle.
-   * Presented to the solver as three size-1 double parameters.
-   * @param sample A double pointer which contains {x, y, r_sqrt}.
-   */
-  template<typename T>
-  bool operator()(const T* const sample,
-                  T* residual) const
-  {
-    T r = sample[2] * sample[2];
-
-    T x_pos = x_ - sample[0];
-    T y_pos = y_ - sample[1];
-
-    residual[0] = r * r - x_pos * x_pos - y_pos * y_pos;
-    return true;
-  }
-
-  /**
-   * @brief An alternative formulation of a residual function for error relative to the center of a circle.
-   * Here, the inputs (x, y, r_sqrt) are provided as separate parameters. This is mathematically identical to the previous version,
-   * but the number and size of the parameters are presented differently to the solver (one size-3 double parameter).
-   * @param x_sample The x-coordinate of the center of the circle.
-   * @param y_sample The y-coordinate of the center of the circle.
-   * @param r_sqrt_sample The square root of the radius of the circle.
-   */
-  template<typename T>
-  bool operator()(const T* const x_sample,
-                  const T* const y_sample,
-                  const T* const r_sqrt_sample,
-                  T* residual) const
-  {
-    T r = r_sqrt_sample * r_sqrt_sample;  // Using sqrt(radius) prevents the radius from ending up negative and improves numerical stability.
-
-    T x_pos = x_ - x_sample;
-    T y_pos = y_ - y_sample;
-
-    residual[0] = r * r - x_pos * x_pos - y_pos * y_pos;
-    return true;
-  }
-
-private:
-  double x_, y_;
-};
-
-}
 
 rct_optimizations::CircleFitResult
 rct_optimizations::optimize(const rct_optimizations::CircleFitProblem& params)
@@ -106,7 +46,7 @@ rct_optimizations::optimize(const rct_optimizations::CircleFitProblem& params)
   result.radius = pow(circle_params[2], 2);
   result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
   result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
-  result.covariance = rct_optimizations::computeDVCovariance(problem, circle_params.data(), 3);
+  result.covariance = rct_optimizations::computeCovariance(problem, std::vector<std::vector<std::string>>({params.labels}));
 
   return result;
 }

--- a/rct_optimizations/src/rct_optimizations/covariance_analysis.cpp
+++ b/rct_optimizations/src/rct_optimizations/covariance_analysis.cpp
@@ -1,4 +1,5 @@
-#include <rct_optimizations/covariance_analysis.h>
+﻿#include <rct_optimizations/covariance_analysis.h>
+#include <sstream>
 
 namespace rct_optimizations
 {
@@ -94,7 +95,12 @@ CovarianceResult computeCovariance(ceres::Problem &problem,
   {
     int block_size = problem.ParameterBlockSize(parameter_blocks[index_block]);
     if (static_cast<std::size_t>(block_size) != parameter_names[index_block].size())
-      throw CovarianceException("Vector of parameter names at index " + std::to_string(index_block) + " in parameter_names is not same length as number of parameter block at index " + std::to_string(index_block) + " in problem");
+    {
+      std::stringstream ss;
+      ss << "Number of parameter labels provided for block " << index_block << " does not match actual number of parameters in that block: " \
+         << "have " << parameter_names[index_block].size() << " labels and " << block_size << " parameters";
+      throw CovarianceException(ss.str());
+    }
     n_params_in_selected += block_size;
   }
 

--- a/rct_optimizations/src/rct_optimizations/covariance_analysis.cpp
+++ b/rct_optimizations/src/rct_optimizations/covariance_analysis.cpp
@@ -3,17 +3,22 @@
 namespace rct_optimizations
 {
 
-Eigen::MatrixXd covToEigenCorr(const double* cov, const std::size_t num_vars)
+Eigen::MatrixXd computeCorrelationsFromCovariance(const Eigen::MatrixXd& covariance_matrix)
 {
+  if(covariance_matrix.rows() != covariance_matrix.cols())
+    throw CovarianceException("Cannot compute correlations from non-square covariance matrix");
+
+  Eigen::Index num_vars = covariance_matrix.rows();
+
   Eigen::MatrixXd out(num_vars, num_vars);
 
-  for (std::size_t i = 0; i < num_vars; i++)
+  for (Eigen::Index i = 0; i < num_vars; i++)
   {
-    double sigma_i = sqrt(fabs(cov[i * num_vars + i]));  // standard deviation at the diagonal element in row i
+    double sigma_i = sqrt(fabs(covariance_matrix(i, i)));  // standard deviation at the diagonal element in row i
 
-    for (std::size_t j = 0; j < num_vars; j++)
+    for (Eigen::Index j = 0; j < num_vars; j++)
     {
-      double sigma_j = sqrt(fabs(cov[j * num_vars + j]));  // standard deviation at the diagonal element in column j
+      double sigma_j = sqrt(fabs(covariance_matrix(j, j)));  // standard deviation at the diagonal element in column j
 
       if (i == j)  // if out(i,j) is a diagonal element
         out(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) = sigma_i;
@@ -22,132 +27,167 @@ Eigen::MatrixXd covToEigenCorr(const double* cov, const std::size_t num_vars)
         if (sigma_i < std::numeric_limits<double>::epsilon()) sigma_i = 1;
         if (sigma_j < std::numeric_limits<double>::epsilon()) sigma_j = 1;
 
-        out(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) = cov[i * num_vars + j] / (sigma_i * sigma_j);
+        out(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) = covariance_matrix(i, j) / (sigma_i * sigma_j);
       }
     }
   }
+
   return out;
 }
 
-Eigen::MatrixXd covToEigenCov(const double* cov, const std::size_t num_vars)
+CovarianceResult computeCovariance(ceres::Problem &problem,
+                                   const ceres::Covariance::Options& options)
 {
-  Eigen::MatrixXd out(num_vars, num_vars);
+  std::vector<double *> blocks;
+  problem.GetParameterBlocks(&blocks);
 
-  for (std::size_t i = 0; i < num_vars; i++)
+  const std::vector<const double *> blocks_const(blocks.begin(), blocks.end());
+
+  return computeCovariance(problem, blocks_const, options);
+}
+
+CovarianceResult computeCovariance(ceres::Problem &problem,
+                                   const std::vector<const double *>& parameter_blocks,
+                                   const ceres::Covariance::Options& options)
+{
+  std::vector<std::vector<std::string>> dummy_param_names;
+  for (std::size_t block_index = 0; block_index < parameter_blocks.size(); block_index++)
   {
-    for (std::size_t j = 0; j < num_vars; j++)
+    int size = problem.ParameterBlockSize(parameter_blocks[block_index]);
+    std::vector<std::string> block_names;
+    for (int i = 0; i < size; i++)
     {
-      out(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) = cov[i * num_vars + j];
+      // names follow format "blockN_elementM"
+       block_names.emplace_back("block" + std::to_string(block_index) + "_element" + std::to_string(i));
     }
+    dummy_param_names.push_back(block_names);
   }
-  return out;
+
+  return computeCovariance(problem, parameter_blocks, dummy_param_names, options);
+
 }
 
-Eigen::MatrixXd covToEigenOffDiagCorr(const double* cov_d1d1, const std::size_t num_vars1, const double* cov_d2d2, const std::size_t num_vars2, const double* cov_d1d2)
+CovarianceResult computeCovariance(ceres::Problem &problem,
+                                   const std::vector<std::vector<std::string>>& parameter_names,
+                                   const ceres::Covariance::Options& options)
 {
-  Eigen::MatrixXd out(num_vars1, num_vars2);
+  // Get all parameter blocks for the problem
+  std::vector<double *> parameter_blocks(static_cast<std::size_t>(problem.NumParameterBlocks()));
+  problem.GetParameterBlocks(&parameter_blocks);
 
-  for (std::size_t i = 0; i < num_vars1; i++)
+  const std::vector<const double *> param_blocks_const(parameter_blocks.begin(), parameter_blocks.end());
+
+  return computeCovariance(problem, param_blocks_const, parameter_names, options);
+}
+
+CovarianceResult computeCovariance(ceres::Problem &problem,
+                                   const std::vector<const double *>& parameter_blocks,
+                                   const std::vector<std::vector<std::string>>& parameter_names,
+                                   const ceres::Covariance::Options& options)
   {
-    double sigma_i = sqrt(fabs(cov_d1d1[i * num_vars1 + i]));  // standard deviation at the diagonal element in row i of cov_d1d1
-    for (std::size_t j = 0; j < num_vars2; j++)
-    {
-      double sigma_j = sqrt(fabs(cov_d2d2[j * num_vars2 + j]));  // standard deviation at the diagonal element in column j of cov_d2d2
+  // 0. Check user-specified arguments
+  if (parameter_blocks.size() != parameter_names.size())  // BUG: wrong for variable number of blocks
+    throw CovarianceException("Provided vector parameter_names is not same length as provided number of parameter blocks");
 
-      if (sigma_i < std::numeric_limits<double>::epsilon()) sigma_i = 1;
-      if (sigma_j < std::numeric_limits<double>::epsilon()) sigma_j = 1;
-
-      out(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) = cov_d1d2[i * num_vars1 + j] / (sigma_i * sigma_j);
-    }
+  Eigen::Index n_params_in_selected = 0;
+  for (std::size_t index_block = 0; index_block < parameter_blocks.size(); index_block++)
+  {
+    int block_size = problem.ParameterBlockSize(parameter_blocks[index_block]);
+    if (static_cast<std::size_t>(block_size) != parameter_names[index_block].size())
+      throw CovarianceException("Vector of parameter names at index " + std::to_string(index_block) + " in parameter_names is not same length as number of parameter block at index " + std::to_string(index_block) + " in problem");
+    n_params_in_selected += block_size;
   }
-  return out;
-}
 
-Eigen::MatrixXd computePoseCovariance(ceres::Problem& problem, const Pose6d& pose, const ceres::Covariance::Options& options)
-{
-  return computeDVCovariance(problem, pose.values.data(), 6, options);
-}
-
-Eigen::MatrixXd computePose2DVCovariance(ceres::Problem &problem, const Pose6d &pose, const double* dptr, std::size_t num_vars, const ceres::Covariance::Options& options)
-{
-  return computeDV2DVCovariance(problem, pose.values.data(), 6, dptr, num_vars, options);
-}
-
-Eigen::MatrixXd computePose2PoseCovariance(ceres::Problem &problem, const Pose6d &p1, const Pose6d &p2, const ceres::Covariance::Options& options)
-{
-  return computeDV2DVCovariance(problem, p1.values.data(), 6, p2.values.data(), 6, options);
-}
-
-Eigen::MatrixXd computeDVCovariance(ceres::Problem &problem, const double * dptr, const std::size_t& num_vars, const ceres::Covariance::Options& options)
-{
+  // 1. Compute covariance matrix
   ceres::Covariance covariance(options);
 
-  std::vector<std::pair<const double*, const double*> > covariance_pairs;
-  covariance_pairs.push_back(std::make_pair(dptr, dptr));
+  if(!covariance.Compute(parameter_blocks, &problem))
+    throw CovarianceException("Could not compute covariance in computeCovariance()");
 
-  if(!covariance.Compute(covariance_pairs, &problem))
-    throw CovarianceException("Could not compute covariance in computeDVCovariance()");
+  Eigen::MatrixXd cov_matrix(n_params_in_selected, n_params_in_selected);
+  if (!covariance.GetCovarianceMatrix(parameter_blocks, cov_matrix.data()))
+  {
+    throw CovarianceException("GetCovarianceMatrix failed in computeCovariance()");
+  }
 
-  double cov[num_vars*num_vars];
-  if(!covariance.GetCovarianceBlock(dptr, dptr, cov))
-    throw CovarianceException("GetCovarianceBlock failed in computeDVCovariance()");
+  // 2. Save original covariance output
+  CovarianceResult res;
+  res.covariance_matrix = cov_matrix;
 
-  return covToEigenCorr(cov, num_vars);
+  // 3. Compute matrix of standard deviations and correlation coefficients, and save to result
+  Eigen::MatrixXd correlation_matrix = computeCorrelationsFromCovariance(cov_matrix);
+  res.correlation_matrix = correlation_matrix;
+
+  std::vector<std::string> parameter_names_concatenated;
+  for (auto names : parameter_names)
+  {
+    parameter_names_concatenated.insert(parameter_names_concatenated.end(), names.begin(), names.end());
+  }
+
+  // 4. Create NamedParams for covariance and correlation results, which include labels and values for the parameters. Uses top-right triangular part of matrix.
+  Eigen::Index col_start = 0;
+  for (Eigen::Index row = 0; row < correlation_matrix.rows(); row++)
+  {
+    for (Eigen::Index col = col_start; col < correlation_matrix.rows(); col++)
+    {
+      NamedParam p_corr;
+      p_corr.value = correlation_matrix(row, col);
+
+      if (row == col)  // diagonal element, standard deviation
+      {
+        p_corr.names = std::make_pair(parameter_names_concatenated[static_cast<std::size_t>(row)], "");
+        res.standard_deviations.push_back(p_corr);
+        continue;
+      }
+
+      // otherwise off-diagonal element, correlation coefficient
+      p_corr.names = std::make_pair(parameter_names_concatenated[static_cast<std::size_t>(row)], parameter_names_concatenated[static_cast<std::size_t>(col)]);
+      res.correlation_coeffs.push_back(p_corr);
+
+      // for off-diagonal elements also get covariance
+      NamedParam p_cov;
+      p_cov.value = cov_matrix(row, col);
+      p_cov.names = std::make_pair(parameter_names_concatenated[static_cast<std::size_t>(row)], parameter_names_concatenated[static_cast<std::size_t>(col)]);
+      res.covariances.push_back(p_cov);
+    }
+    col_start++;
+  }
+
+  return res;
 }
 
-Eigen::MatrixXd computeDV2DVCovariance(ceres::Problem &P, const double* dptr1, const std::size_t num_vars1, const double* dptr2, const std::size_t num_vars2, const ceres::Covariance::Options& options)
-{
-  ceres::Covariance covariance(options);
+//Eigen::MatrixXd computeFullDV2DVCovariance(ceres::Problem &problem,
+//                                           const double *dptr1,
+//                                           const std::size_t num_vars1,
+//                                           const double *dptr2,
+//                                           const std::size_t num_vars2,
+//                                           const ceres::Covariance::Options &options)
+//{
+//  // Calculate the individual covariance matrices
+//  // Covariance of parameter 1 with itself
+//  Eigen::MatrixXd cov_p1 = computeDVCovariance(problem, dptr1, num_vars1, options);
+//  // Covariance of parameter 2 with itself
+//  Eigen::MatrixXd cov_p2 = computeDVCovariance(problem, dptr2, num_vars2, options);
+//  // Covariance of parameter 1 with parameter 2
+//  Eigen::MatrixXd cov_p1p2
+//    = computeDV2DVCovariance(problem, dptr1, num_vars1, dptr2, num_vars2, options);
 
-  std::vector<std::pair<const double*, const double*> > covariance_pairs;
-  covariance_pairs.push_back(std::make_pair(dptr1, dptr1));
-  covariance_pairs.push_back(std::make_pair(dptr2, dptr2));
-  covariance_pairs.push_back(std::make_pair(dptr1, dptr2));
+//  // Total covariance matrix
+//  Eigen::MatrixXd cov;
+//  const std::size_t n = num_vars1 + num_vars2;
+//  cov.resize(n, n);
 
-  if(!covariance.Compute(covariance_pairs, &P))
-    throw CovarianceException("Could not compute covariance in computeDV2DVCovariance()");
+//  /*    |     P1    |     P2    |
+//   * ---|-----------|-----------|
+//   * P1 | C(p1, p1) | C(p1, p2) |
+//   * P2 | C(p2, p1) | C(p2, p2) |
+//   */
+//  cov.block(0, 0, num_vars1, num_vars1) = cov_p1;
+//  cov.block(num_vars1, num_vars1, num_vars2, num_vars2) = cov_p2;
+//  cov.block(0, num_vars1, num_vars1, num_vars2) = cov_p1p2;
+//  cov.block(num_vars1, 0, num_vars2, num_vars1) = cov_p1p2.transpose();
 
-  double cov_d1d1[num_vars1*num_vars2], cov_d2d2[num_vars2*num_vars2], cov_d1d2[num_vars1*num_vars2];
-  if(!(covariance.GetCovarianceBlock(dptr1, dptr1, cov_d1d1) &&
-       covariance.GetCovarianceBlock(dptr2, dptr2, cov_d2d2) &&
-       covariance.GetCovarianceBlock(dptr1, dptr2, cov_d1d2)))
-    throw CovarianceException("GetCovarianceBlock failed in computeDV2DVCovariance()");
-
-  return covToEigenOffDiagCorr(cov_d1d1, num_vars1, cov_d2d2, num_vars2, cov_d1d2);
-}
-
-Eigen::MatrixXd computeFullDV2DVCovariance(ceres::Problem &problem,
-                                           const double *dptr1,
-                                           const std::size_t num_vars1,
-                                           const double *dptr2,
-                                           const std::size_t num_vars2,
-                                           const ceres::Covariance::Options &options)
-{
-  // Calculate the individual covariance matrices
-  // Covariance of parameter 1 with itself
-  Eigen::MatrixXd cov_p1 = computeDVCovariance(problem, dptr1, num_vars1, options);
-  // Covariance of parameter 2 with itself
-  Eigen::MatrixXd cov_p2 = computeDVCovariance(problem, dptr2, num_vars2, options);
-  // Covariance of parameter 1 with parameter 2
-  Eigen::MatrixXd cov_p1p2
-    = computeDV2DVCovariance(problem, dptr1, num_vars1, dptr2, num_vars2, options);
-
-  // Total covariance matrix
-  Eigen::MatrixXd cov;
-  const std::size_t n = num_vars1 + num_vars2;
-  cov.resize(n, n);
-
-  /*    |     P1    |     P2    |
-   * ---|-----------|-----------|
-   * P1 | C(p1, p1) | C(p1, p2) |
-   * P2 | C(p2, p1) | C(p2, p2) |
-   */
-  cov.block(0, 0, num_vars1, num_vars1) = cov_p1;
-  cov.block(num_vars1, num_vars1, num_vars2, num_vars2) = cov_p2;
-  cov.block(0, num_vars1, num_vars1, num_vars2) = cov_p1p2;
-  cov.block(num_vars1, 0, num_vars2, num_vars1) = cov_p1p2.transpose();
-
-  return cov;
-}
+//  return cov;
+//}
 
 }  // namespace rct_optimizations

--- a/rct_optimizations/src/rct_optimizations/dh_chain.cpp
+++ b/rct_optimizations/src/rct_optimizations/dh_chain.cpp
@@ -6,8 +6,14 @@ namespace rct_optimizations
 // DH Transform
 
 DHTransform::DHTransform(const Eigen::Vector4d &params_, DHJointType type_)
+  : DHTransform(params_, type_, "joint")
+{
+}
+
+DHTransform::DHTransform(const Eigen::Vector4d &params_, DHJointType type_, const std::string& name_)
   : params(params_)
   , type(type_)
+  , name(name_)
 {
 }
 
@@ -21,6 +27,16 @@ double DHTransform::createRandomJointValue() const
 
   return dist(mt_rand);
 }
+
+std::array<std::string, 4> DHTransform::getParamLabels() const
+{
+  return  std::array<std::string, 4>({name + "_d",
+                                      name + "_theta",
+                                      name + "_r",
+                                      name + "_alpha",
+                                      });
+}
+
 
 // DH Chain
 
@@ -64,5 +80,16 @@ std::vector<DHJointType> DHChain::getJointTypes() const
   }
   return out;
 }
+
+std::vector<std::array<std::string, 4>> DHChain::getParamLabels() const
+{
+  std::vector<std::array<std::string, 4>> out;
+  for (const auto &t : transforms_)
+  {
+    out.push_back(t.getParamLabels());
+  }
+  return out;
+}
+
 
 } // namespace rct_optimizations

--- a/rct_optimizations/src/rct_optimizations/extrinsic_multi_static_camera_only.cpp
+++ b/rct_optimizations/src/rct_optimizations/extrinsic_multi_static_camera_only.cpp
@@ -165,5 +165,6 @@ rct_optimizations::optimize(const rct_optimizations::ExtrinsicMultiStaticCameraO
 
   result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
   result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
+
   return result;
 }

--- a/rct_optimizations/src/rct_optimizations/pnp.cpp
+++ b/rct_optimizations/src/rct_optimizations/pnp.cpp
@@ -1,7 +1,6 @@
 #include "rct_optimizations/pnp.h"
 #include "rct_optimizations/ceres_math_utilities.h"
 #include "rct_optimizations/covariance_analysis.h"
-
 #include <ceres/ceres.h>
 
 namespace
@@ -117,11 +116,30 @@ PnPResult optimize(const PnPProblem &params)
   result.camera_to_target = Eigen::Translation3d(cam_to_tgt_translation)
                             * Eigen::AngleAxisd(cam_to_tgt_angle_axis.norm(),
                                                 cam_to_tgt_angle_axis.normalized());
-  result.camera_to_target_covariance = computeFullDV2DVCovariance(problem,
-                                                                  cam_to_tgt_translation.data(),
-                                                                  cam_to_tgt_translation.size(),
-                                                                  cam_to_tgt_angle_axis.data(),
-                                                                  cam_to_tgt_angle_axis.size());
+//  result.camera_to_target_covariance = computeFullDV2DVCovariance(problem,
+//                                                                  cam_to_tgt_translation.data(),
+//                                                                  cam_to_tgt_translation.size(),
+//                                                                  cam_to_tgt_angle_axis.data(),
+//                                                                  cam_to_tgt_angle_axis.size());
+
+  // compose labels "camera_to_target_x", etc.
+  std::vector<std::string> labels_camera_to_target_guess_translation;
+  for (auto label_t : params.labels_translation)
+  {
+    labels_camera_to_target_guess_translation.emplace_back(params.label_camera_to_target_guess + "_" + label_t);
+  }
+
+  // compose labels "camera_to_target_qx", etc.
+  std::vector<std::string> labels_camera_to_target_guess_quaternion;
+  for (auto label_r : params.labels_rotation)
+  {
+    labels_camera_to_target_guess_quaternion.emplace_back(params.label_camera_to_target_guess + "_" + label_r);
+  }
+  std::vector<std::vector<std::string>> param_labels = { labels_camera_to_target_guess_translation, labels_camera_to_target_guess_quaternion };
+
+  result.covariance = rct_optimizations::computeCovariance(problem,
+                                                           std::vector<const double *>({cam_to_tgt_translation.data(), cam_to_tgt_angle_axis.data()}),
+                                                           param_labels);
 
   return result;
 }
@@ -159,11 +177,11 @@ PnPResult optimize(const rct_optimizations::PnPProblem3D& params)
   result.camera_to_target = Eigen::Translation3d(cam_to_tgt_translation)
                             * Eigen::AngleAxisd(cam_to_tgt_angle_axis.norm(),
                                                 cam_to_tgt_angle_axis.normalized());
-  result.camera_to_target_covariance = computeFullDV2DVCovariance(problem,
-                                                                  cam_to_tgt_translation.data(),
-                                                                  cam_to_tgt_translation.size(),
-                                                                  cam_to_tgt_angle_axis.data(),
-                                                                  cam_to_tgt_angle_axis.size());
+//  result.covariance = computeFullDV2DVCovariance(problem,
+//                                                                  cam_to_tgt_translation.data(),
+//                                                                  cam_to_tgt_translation.size(),
+//                                                                  cam_to_tgt_angle_axis.data(),
+//                                                                  cam_to_tgt_angle_axis.size());
 
   return result;
 }

--- a/rct_optimizations/src/rct_optimizations/pnp.cpp
+++ b/rct_optimizations/src/rct_optimizations/pnp.cpp
@@ -116,11 +116,6 @@ PnPResult optimize(const PnPProblem &params)
   result.camera_to_target = Eigen::Translation3d(cam_to_tgt_translation)
                             * Eigen::AngleAxisd(cam_to_tgt_angle_axis.norm(),
                                                 cam_to_tgt_angle_axis.normalized());
-//  result.camera_to_target_covariance = computeFullDV2DVCovariance(problem,
-//                                                                  cam_to_tgt_translation.data(),
-//                                                                  cam_to_tgt_translation.size(),
-//                                                                  cam_to_tgt_angle_axis.data(),
-//                                                                  cam_to_tgt_angle_axis.size());
 
   // compose labels "camera_to_target_x", etc.
   std::vector<std::string> labels_camera_to_target_guess_translation;
@@ -177,11 +172,25 @@ PnPResult optimize(const rct_optimizations::PnPProblem3D& params)
   result.camera_to_target = Eigen::Translation3d(cam_to_tgt_translation)
                             * Eigen::AngleAxisd(cam_to_tgt_angle_axis.norm(),
                                                 cam_to_tgt_angle_axis.normalized());
-//  result.covariance = computeFullDV2DVCovariance(problem,
-//                                                                  cam_to_tgt_translation.data(),
-//                                                                  cam_to_tgt_translation.size(),
-//                                                                  cam_to_tgt_angle_axis.data(),
-//                                                                  cam_to_tgt_angle_axis.size());
+
+  // compose labels "camera_to_target_x", etc.
+  std::vector<std::string> labels_camera_to_target_guess_translation;
+  for (auto label_t : params.labels_translation)
+  {
+    labels_camera_to_target_guess_translation.emplace_back(params.label_camera_to_target_guess + "_" + label_t);
+  }
+
+  // compose labels "camera_to_target_qx", etc.
+  std::vector<std::string> labels_camera_to_target_guess_quaternion;
+  for (auto label_r : params.labels_rotation)
+  {
+    labels_camera_to_target_guess_quaternion.emplace_back(params.label_camera_to_target_guess + "_" + label_r);
+  }
+  std::vector<std::vector<std::string>> param_labels = { labels_camera_to_target_guess_translation, labels_camera_to_target_guess_quaternion };
+
+  result.covariance = rct_optimizations::computeCovariance(problem,
+                                                           std::vector<const double *>({cam_to_tgt_translation.data(), cam_to_tgt_angle_axis.data()}),
+                                                           param_labels);
 
   return result;
 }

--- a/rct_optimizations/test/covariance_utest.cpp
+++ b/rct_optimizations/test/covariance_utest.cpp
@@ -4,6 +4,8 @@
 #include <functional>
 
 // Optimization for tests
+#include <ceres/ceres.h>
+#include <rct_optimizations/covariance_analysis.h>
 #include <rct_optimizations/circle_fit.h>
 
 template <typename T>
@@ -44,7 +46,8 @@ protected:
     std::cout << "X: " << r.x_center << std::endl;
     std::cout << "Y: " << r.y_center << std::endl;
     std::cout << "R: " << r.radius << std::endl;
-    std::cout << "Covariance Matrix:\n" << r.covariance.matrix() << std::endl;
+    std::cout << "Covariance Matrix:\n" << r.covariance.covariance_matrix.matrix() << std::endl;
+    std::cout << r.covariance.toString() << std::endl;
   }
 
   std::double_t center_x_actual, center_y_actual, radius_actual;
@@ -232,26 +235,81 @@ TEST_F(CircleFitUnit_PerfectObservations_RandomGuess, FitCircleToPerfectObs)
   EXPECT_NEAR(radius_actual, result.radius, 1e-5);
 
   // assert 3x3 covariance matrix
-  ASSERT_EQ(result.covariance.rows(), 3);
-  ASSERT_EQ(result.covariance.cols(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.rows(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.cols(), 3);
 
-  // expect matrix to be symmetric
-  EXPECT_NEAR(result.covariance(0, 1), result.covariance(1, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(0, 2), result.covariance(2, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(1, 2), result.covariance(2, 1), std::numeric_limits<double>::epsilon());
+  // assert 3x3 correlation matrix
+  ASSERT_EQ(result.covariance.correlation_matrix.rows(), 3);
+  ASSERT_EQ(result.covariance.correlation_matrix.cols(), 3);
+
+  // expect both matrices to be symmetric
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 1), result.covariance.covariance_matrix(1, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 2), result.covariance.covariance_matrix(2, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(1, 2), result.covariance.covariance_matrix(2, 1), std::numeric_limits<double>::epsilon());
+  EXPECT_TRUE(result.covariance.covariance_matrix.isApprox(result.covariance.covariance_matrix.transpose()));  // TODO: use this instead in future
+
+  EXPECT_TRUE(result.covariance.correlation_matrix.isApprox(result.covariance.correlation_matrix.transpose()));
 
   // expect diagonal elements to be positive
-  EXPECT_GE(result.covariance(0, 0), 0.0);
-  EXPECT_GE(result.covariance(1, 1), 0.0);
-  EXPECT_GE(result.covariance(2, 2), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(0, 0), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(1, 1), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
+  EXPECT_GE(result.covariance.correlation_matrix(0, 0), 0.0);
+  EXPECT_GE(result.covariance.correlation_matrix(1, 1), 0.0);
+  EXPECT_GE(result.covariance.correlation_matrix(2, 2), 0.0);
 
   // expect off-diagonal elements to be near-zero
-  EXPECT_NEAR(result.covariance(0, 1), 0.0, 1e-5);
-  EXPECT_NEAR(result.covariance(0, 2), 0.0, 1e-5);
-  EXPECT_NEAR(result.covariance(1, 2), 0.0, 1e-5);
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 1), 0.0, 1e-5);
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 2), 0.0, 1e-5);
+  EXPECT_NEAR(result.covariance.covariance_matrix(1, 2), 0.0, 1e-5);
 
   // with perfect evenly-spaced observations we expect the standard deviations of X and Y to be near-identical
-  EXPECT_NEAR(result.covariance(0, 0), result.covariance(1, 1), 1e-5);
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 0), result.covariance.covariance_matrix(1, 1), 1e-5);
+
+  // checks for NamedParam output
+  // expect three parameters for standard deviations
+  ASSERT_EQ(result.covariance.standard_deviations.size(), 3);
+
+  // expect three parameters for off-diagonal covariance
+  ASSERT_EQ(result.covariance.covariances.size(), 3);
+
+  // expect three parameters for off-diagonal correlation coefficients
+  ASSERT_EQ(result.covariance.correlation_coeffs.size(), 3);
+
+  // expect names to match what was set in the problem
+  EXPECT_EQ(result.covariance.standard_deviations[0].names.first, problem.labels[0]);
+  EXPECT_EQ(result.covariance.standard_deviations[0].names.second, "");
+  EXPECT_EQ(result.covariance.standard_deviations[1].names.first, problem.labels[1]);
+  EXPECT_EQ(result.covariance.standard_deviations[1].names.second, "");
+  EXPECT_EQ(result.covariance.standard_deviations[2].names.first, problem.labels[2]);
+  EXPECT_EQ(result.covariance.standard_deviations[2].names.second, "");
+
+  EXPECT_EQ(result.covariance.covariances[0].names.first, problem.labels[0]);
+  EXPECT_EQ(result.covariance.covariances[0].names.second, problem.labels[1]);
+  EXPECT_EQ(result.covariance.covariances[1].names.first, problem.labels[0]);
+  EXPECT_EQ(result.covariance.covariances[1].names.second, problem.labels[2]);
+  EXPECT_EQ(result.covariance.covariances[2].names.first, problem.labels[1]);
+  EXPECT_EQ(result.covariance.covariances[2].names.second, problem.labels[2]);
+
+  EXPECT_EQ(result.covariance.correlation_coeffs[0].names.first, problem.labels[0]);
+  EXPECT_EQ(result.covariance.correlation_coeffs[0].names.second, problem.labels[1]);
+  EXPECT_EQ(result.covariance.correlation_coeffs[1].names.first, problem.labels[0]);
+  EXPECT_EQ(result.covariance.correlation_coeffs[1].names.second, problem.labels[2]);
+  EXPECT_EQ(result.covariance.correlation_coeffs[2].names.first, problem.labels[1]);
+  EXPECT_EQ(result.covariance.correlation_coeffs[2].names.second, problem.labels[2]);
+
+  // expect values to match contents of matrices
+  EXPECT_EQ(result.covariance.standard_deviations[0].value, result.covariance.correlation_matrix(0, 0));
+  EXPECT_EQ(result.covariance.standard_deviations[1].value, result.covariance.correlation_matrix(1, 1));
+  EXPECT_EQ(result.covariance.standard_deviations[2].value, result.covariance.correlation_matrix(2, 2));
+
+  EXPECT_EQ(result.covariance.covariances[0].value, result.covariance.covariance_matrix(0, 1));
+  EXPECT_EQ(result.covariance.covariances[1].value, result.covariance.covariance_matrix(0, 2));
+  EXPECT_EQ(result.covariance.covariances[2].value, result.covariance.covariance_matrix(1, 2));
+
+  EXPECT_EQ(result.covariance.correlation_coeffs[0].value, result.covariance.correlation_matrix(0, 1));
+  EXPECT_EQ(result.covariance.correlation_coeffs[1].value, result.covariance.correlation_matrix(0, 2));
+  EXPECT_EQ(result.covariance.correlation_coeffs[2].value, result.covariance.correlation_matrix(1, 2));
 }
 
 TEST_F(CircleFitUnit_ClusteredObservations, FitCircleToClusteredObs)
@@ -261,21 +319,21 @@ TEST_F(CircleFitUnit_ClusteredObservations, FitCircleToClusteredObs)
   printResults(result);
 
   // assert 3x3 covariance matrix
-  ASSERT_EQ(result.covariance.rows(), 3);
-  ASSERT_EQ(result.covariance.cols(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.rows(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.cols(), 3);
 
   // expect matrix to be symmetric
-  EXPECT_NEAR(result.covariance(0, 1), result.covariance(1, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(0, 2), result.covariance(2, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(1, 2), result.covariance(2, 1), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 1), result.covariance.covariance_matrix(1, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 2), result.covariance.covariance_matrix(2, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(1, 2), result.covariance.covariance_matrix(2, 1), std::numeric_limits<double>::epsilon());
 
   // expect diagonal elements to be positive
-  EXPECT_GE(result.covariance(0, 0), 0.0);
-  EXPECT_GE(result.covariance(1, 1), 0.0);
-  EXPECT_GE(result.covariance(2, 2), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(0, 0), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(1, 1), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
 
   // std dev of Y-coord should be greater than std dev of X-coord
-  EXPECT_GT(result.covariance(1, 1), result.covariance(0, 0));
+  EXPECT_GT(result.covariance.covariance_matrix(1, 1), result.covariance.covariance_matrix(0, 0));
 }
 
 TEST_F(CircleFitUnit_ClusteredObservationsPerturbed, FitCircleToClusteredObsPerturbed)
@@ -285,21 +343,21 @@ TEST_F(CircleFitUnit_ClusteredObservationsPerturbed, FitCircleToClusteredObsPert
   printResults(result);
 
   // assert 3x3 covariance matrix
-  ASSERT_EQ(result.covariance.rows(), 3);
-  ASSERT_EQ(result.covariance.cols(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.rows(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.cols(), 3);
 
   // expect matrix to be symmetric
-  EXPECT_NEAR(result.covariance(0, 1), result.covariance(1, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(0, 2), result.covariance(2, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(1, 2), result.covariance(2, 1), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 1), result.covariance.covariance_matrix(1, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 2), result.covariance.covariance_matrix(2, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(1, 2), result.covariance.covariance_matrix(2, 1), std::numeric_limits<double>::epsilon());
 
   // expect diagonal elements to be positive
-  EXPECT_GE(result.covariance(0, 0), 0.0);
-  EXPECT_GE(result.covariance(1, 1), 0.0);
-  EXPECT_GE(result.covariance(2, 2), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(0, 0), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(1, 1), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
 
   // std dev of Y-coord should be greater than std dev of X-coord
-  EXPECT_GT(result.covariance(1, 1), result.covariance(0, 0));
+  EXPECT_GT(result.covariance.covariance_matrix(1, 1), result.covariance.covariance_matrix(0, 0));
 }
 
 // Do optimization to fit a circle to two observed points.
@@ -310,27 +368,31 @@ TEST_F(CircleFitUnit_TwoObsX, FitCircleToTwoPoints)
   printResults(result);
 
   // assert 3x3 covariance matrix
-  ASSERT_EQ(result.covariance.rows(), 3);
-  ASSERT_EQ(result.covariance.cols(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.rows(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.cols(), 3);
 
   // expect matrix to be symmetric
   // BUG: flaky way to evaluate, since difference is sometimes (but rarely) greater than epsilon
-  EXPECT_NEAR(result.covariance(0, 1), result.covariance(1, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(0, 2), result.covariance(2, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(1, 2), result.covariance(2, 1), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 1), result.covariance.covariance_matrix(1, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 2), result.covariance.covariance_matrix(2, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(1, 2), result.covariance.covariance_matrix(2, 1), std::numeric_limits<double>::epsilon());
 
   // expect diagonal elements to be positive
-  EXPECT_GE(result.covariance(0, 0), 0.0);
-  EXPECT_GE(result.covariance(1, 1), 0.0);
-  EXPECT_GE(result.covariance(2, 2), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(0, 0), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(1, 1), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
 
-  // expect covariance between Y and R to be close to 1
-  EXPECT_NEAR(abs(result.covariance(1, 2)), 1.0, 1e-5);
+  // expect covariance.covariance_matrix between Y and R to be close to 1
+  EXPECT_NEAR(abs(result.covariance.correlation_matrix(1, 2)), 1.0, 1e-5);
 
   // expect covariance between X and R to be somewhat close to 0
   // TODO: fix, not always close to zero due to random initial conditions of problem
 //  EXPECT_NEAR(result.covariance(0, 2), 0.0, 1e-2);
 
+  // expect correlation coefficient between y and r to be comparatively large, and all others to be small
+  std::vector<rct_optimizations::NamedParam> outside_thresh = result.covariance.getCorrelationCoeffOutsideThreshold(0.1);
+  EXPECT_EQ(outside_thresh.size(), 1);
+  EXPECT_EQ(outside_thresh.front().names, std::make_pair(std::string("y"), std::string("r")));
 }
 
 // Do optimization to fit a circle to two observed points.
@@ -341,25 +403,30 @@ TEST_F(CircleFitUnit_TwoObsY, FitCircleToTwoPoints)
   printResults(result);
 
   // assert 3x3 covariance matrix
-  ASSERT_EQ(result.covariance.rows(), 3);
-  ASSERT_EQ(result.covariance.cols(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.rows(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.cols(), 3);
 
   // expect matrix to be symmetric
-  EXPECT_NEAR(result.covariance(0, 1), result.covariance(1, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(0, 2), result.covariance(2, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(1, 2), result.covariance(2, 1), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 1), result.covariance.covariance_matrix(1, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 2), result.covariance.covariance_matrix(2, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(1, 2), result.covariance.covariance_matrix(2, 1), std::numeric_limits<double>::epsilon());
 
   // expect diagonal elements to be positive
-  EXPECT_GE(result.covariance(0, 0), 0.0);
-  EXPECT_GE(result.covariance(1, 1), 0.0);
-  EXPECT_GE(result.covariance(2, 2), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(0, 0), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(1, 1), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
 
   // expect covariance between X and R to be close to 1
-  EXPECT_NEAR(abs(result.covariance(0, 2)), 1.0, 1e-5);
+  EXPECT_NEAR(abs(result.covariance.correlation_matrix(0, 2)), 1.0, 1e-5);
 
   // expect covariance between Y and R to be somewhat close to 0
   // TODO: fix, not always close to zero due to random initial conditions of problem
 //  EXPECT_NEAR(result.covariance(1, 2), 0.0, 1e-2);
+
+  // expect correlation coefficient between x and r to be comparatively large, and all others to be small
+  std::vector<rct_optimizations::NamedParam> outside_thresh = result.covariance.getCorrelationCoeffOutsideThreshold(0.1);
+  EXPECT_EQ(outside_thresh.size(), 1);
+  EXPECT_EQ(outside_thresh.front().names, std::make_pair(std::string("x"), std::string("r")));
 }
 
 // Do optimization to fit a circle to just one observed point.
@@ -370,23 +437,27 @@ TEST_F(CircleFitUnit_OneObs, FitCircleToOnePoint)
   printResults(result);
 
   // assert 3x3 covariance matrix
-  ASSERT_EQ(result.covariance.rows(), 3);
-  ASSERT_EQ(result.covariance.cols(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.rows(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.cols(), 3);
 
   // expect matrix to be symmetric
-  EXPECT_NEAR(result.covariance(0, 1), result.covariance(1, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(0, 2), result.covariance(2, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(1, 2), result.covariance(2, 1), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 1), result.covariance.covariance_matrix(1, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 2), result.covariance.covariance_matrix(2, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(1, 2), result.covariance.covariance_matrix(2, 1), std::numeric_limits<double>::epsilon());
 
   // expect diagonal elements to be positive
-  EXPECT_GE(result.covariance(0, 0), 0.0);
-  EXPECT_GE(result.covariance(1, 1), 0.0);
-  EXPECT_GE(result.covariance(2, 2), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(0, 0), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(1, 1), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
 
   // expect magnitudes of all off-diagonal elements to be close to 1
-  EXPECT_NEAR(abs(result.covariance(0, 1)), 1.0, 1e-5);
-  EXPECT_NEAR(abs(result.covariance(0, 2)), 1.0, 1e-5);
-  EXPECT_NEAR(abs(result.covariance(1, 2)), 1.0, 1e-5);
+  EXPECT_NEAR(abs(result.covariance.correlation_matrix(0, 1)), 1.0, 1e-5);
+  EXPECT_NEAR(abs(result.covariance.correlation_matrix(0, 2)), 1.0, 1e-5);
+  EXPECT_NEAR(abs(result.covariance.correlation_matrix(1, 2)), 1.0, 1e-5);
+
+  // expect all correlation coefficients to be greater than 0.1
+  std::vector<rct_optimizations::NamedParam> outside_thresh = result.covariance.getCorrelationCoeffOutsideThreshold(0.1);
+  EXPECT_EQ(outside_thresh.size(), 3);
 }
 
 TEST_F(CircleFitUnit_ThreeObs, FitCircleToThreePoints)
@@ -396,23 +467,172 @@ TEST_F(CircleFitUnit_ThreeObs, FitCircleToThreePoints)
   printResults(result);
 
   // assert 3x3 covariance matrix
-  ASSERT_EQ(result.covariance.rows(), 3);
-  ASSERT_EQ(result.covariance.cols(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.rows(), 3);
+  ASSERT_EQ(result.covariance.covariance_matrix.cols(), 3);
 
   // expect matrix to be symmetric
-  EXPECT_NEAR(result.covariance(0, 1), result.covariance(1, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(0, 2), result.covariance(2, 0), std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(result.covariance(1, 2), result.covariance(2, 1), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 1), result.covariance.covariance_matrix(1, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 2), result.covariance.covariance_matrix(2, 0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(result.covariance.covariance_matrix(1, 2), result.covariance.covariance_matrix(2, 1), std::numeric_limits<double>::epsilon());
 
   // expect diagonal elements to be positive
-  EXPECT_GE(result.covariance(0, 0), 0.0);
-  EXPECT_GE(result.covariance(1, 1), 0.0);
-  EXPECT_GE(result.covariance(2, 2), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(0, 0), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(1, 1), 0.0);
+  EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
 
   // expect off-diagonal elements to be close to 0
-  EXPECT_NEAR(result.covariance(0, 1), 0.0, 1e-5);
-  EXPECT_NEAR(result.covariance(0, 2), 0.0, 1e-5);
-  EXPECT_NEAR(result.covariance(1, 2), 0.0, 1e-5);
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 1), 0.0, 1e-5);
+  EXPECT_NEAR(result.covariance.covariance_matrix(0, 2), 0.0, 1e-5);
+  EXPECT_NEAR(result.covariance.covariance_matrix(1, 2), 0.0, 1e-5);
+
+  // expect all correlation coefficients to be less than 0.1
+  std::vector<rct_optimizations::NamedParam> outside_thresh = result.covariance.getCorrelationCoeffOutsideThreshold(0.1);
+  EXPECT_EQ(outside_thresh.size(), 0);
+}
+
+// This test exercises the the variations of the computeCovariance function.
+// Since these functions are usually set up inside an optimize() function, the CircleFit problem's setup and optimization is duplicated here.
+TEST(CovarianceAnalysis, CovarianceAnalysisFunctions)
+{
+  double x = perturb_random<std::double_t>(0.0, 1.0);
+  double y = perturb_random<std::double_t>(0.0, 1.0);
+  double r = perturb_random<std::double_t>(1.0, 0.9);
+
+  double r_sqrt = sqrt(r);
+
+  std::vector<double> x_internal(1, x);
+  std::vector<double> y_internal(1, y);
+  std::vector<double> r_sqrt_internal(1, r_sqrt);
+
+  std::vector<double> params_internal(3);
+  params_internal[0] = x;
+  params_internal[1] = y;
+  params_internal[2] = r_sqrt;
+
+
+  rct_optimizations::CircleFitResult result;
+
+  ceres::Problem problem;
+
+  ceres::LossFunction* loss_fn = nullptr;
+
+
+  std::vector<Eigen::Vector2d> observations;
+  std::size_t n_obs_target = 50;
+  std::double_t obs_step = 2 * M_PI / n_obs_target;
+  for (std::double_t angle = 0; angle < 2 * M_PI; angle += obs_step)
+  {
+    std::double_t point_x = 1.0 * cos(angle);
+    std::double_t point_y = 1.0 * sin(angle);
+    observations.emplace_back(Eigen::Vector2d(point_x, point_y));
+  }
+
+  for (auto obs : observations)
+  {
+    auto* cost_fn = new rct_optimizations::CircleDistCost(obs.x(), obs.y());
+
+    // This uses the alternative CircleDist cost function where the three optimization variables are separate parameter blocks
+    auto* cost_block = new ceres::AutoDiffCostFunction<rct_optimizations::CircleDistCost, 1, 1, 1, 1>(cost_fn);
+    problem.AddResidualBlock(cost_block, loss_fn, params_internal.data(), params_internal.data()+1, params_internal.data()+2);
+  }
+
+  ceres::Solver::Options options;
+  options.max_num_iterations = 500;
+  options.linear_solver_type = ceres::DENSE_QR;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+
+  std::cout << summary.BriefReport() << std::endl;
+
+  result.converged = summary.termination_type == ceres::TerminationType::CONVERGENCE;
+  result.x_center = params_internal[0];
+  result.y_center = params_internal[1];
+  result.radius = pow(params_internal[2], 2);
+  result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
+  result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
+
+  // sanity-check optimization results
+  ASSERT_TRUE(result.converged);
+  EXPECT_NEAR(0.0, result.x_center, 1e-5);
+  EXPECT_NEAR(0.0, result.y_center, 1e-5);
+  EXPECT_NEAR(1.0, result.radius, 1e-5);
+
+  std::vector<std::vector<std::string>> labels_all({{"circle_x"}, {"circle_y"}, {"circle_r"}});
+  std::vector<std::vector<std::string>> labels_x_r({{"circle_x"}, {"circle_r"}});
+
+  std::vector<const double*> param_blocks_x_r(2);
+  param_blocks_x_r[0] = params_internal.data();
+  param_blocks_x_r[1] = params_internal.data()+2;
+
+  rct_optimizations::CovarianceResult covariance_labeled = rct_optimizations::computeCovariance(problem, labels_all);
+
+  EXPECT_EQ(covariance_labeled.standard_deviations.size(), 3);
+  EXPECT_EQ(covariance_labeled.covariances.size(), 3);
+  EXPECT_EQ(covariance_labeled.correlation_coeffs.size(), 3);
+
+  rct_optimizations::CovarianceResult covariance_generic_names = rct_optimizations::computeCovariance(problem);
+
+  EXPECT_EQ(covariance_generic_names.standard_deviations.size(), 3);
+  EXPECT_EQ(covariance_generic_names.covariances.size(), 3);
+  EXPECT_EQ(covariance_generic_names.correlation_coeffs.size(), 3);
+
+  rct_optimizations::CovarianceResult cov_x_r_generic_names = rct_optimizations::computeCovariance(problem, param_blocks_x_r);
+
+  EXPECT_EQ(cov_x_r_generic_names.standard_deviations.size(), 2);
+  EXPECT_EQ(cov_x_r_generic_names.covariances.size(), 1);
+  EXPECT_EQ(cov_x_r_generic_names.correlation_coeffs.size(), 1);
+
+  EXPECT_EQ(cov_x_r_generic_names.standard_deviations[0].names.first, "block0_element0");
+  EXPECT_EQ(cov_x_r_generic_names.standard_deviations[0].value, covariance_labeled.standard_deviations[0].value);
+
+  EXPECT_EQ(cov_x_r_generic_names.standard_deviations[1].names.first, "block1_element0");
+  EXPECT_EQ(cov_x_r_generic_names.standard_deviations[1].value, covariance_labeled.standard_deviations[2].value);
+
+  EXPECT_EQ(cov_x_r_generic_names.covariances[0].names.first, "block0_element0");
+  EXPECT_EQ(cov_x_r_generic_names.covariances[0].names.second, "block1_element0");
+  EXPECT_EQ(cov_x_r_generic_names.covariances[0].value, covariance_labeled.covariances[1].value);
+
+  EXPECT_EQ(cov_x_r_generic_names.correlation_coeffs[0].names.first, "block0_element0");
+  EXPECT_EQ(cov_x_r_generic_names.correlation_coeffs[0].names.second, "block1_element0");
+  EXPECT_EQ(cov_x_r_generic_names.correlation_coeffs[0].value, covariance_labeled.correlation_coeffs[1].value);
+
+  rct_optimizations::CovarianceResult cov_x_r_labeled = rct_optimizations::computeCovariance(problem, param_blocks_x_r, labels_x_r);
+
+  EXPECT_EQ(cov_x_r_labeled.standard_deviations.size(), 2);
+  EXPECT_EQ(cov_x_r_labeled.covariances.size(), 1);
+  EXPECT_EQ(cov_x_r_labeled.correlation_coeffs.size(), 1);
+
+  EXPECT_EQ(cov_x_r_labeled.standard_deviations[0].names.first, covariance_labeled.standard_deviations[0].names.first);
+  EXPECT_EQ(cov_x_r_labeled.standard_deviations[0].value, covariance_labeled.standard_deviations[0].value);
+
+  EXPECT_EQ(cov_x_r_labeled.standard_deviations[1].names.first, covariance_labeled.standard_deviations[2].names.first);
+  EXPECT_EQ(cov_x_r_labeled.standard_deviations[1].value, covariance_labeled.standard_deviations[2].value);
+
+  EXPECT_EQ(cov_x_r_labeled.covariances[0].names.first, covariance_labeled.covariances[1].names.first);
+  EXPECT_EQ(cov_x_r_labeled.covariances[0].names.second, covariance_labeled.covariances[1].names.second);
+  EXPECT_EQ(cov_x_r_labeled.covariances[0].value, covariance_labeled.covariances[1].value);
+
+  EXPECT_EQ(cov_x_r_labeled.correlation_coeffs[0].names.first, covariance_labeled.correlation_coeffs[1].names.first);
+  EXPECT_EQ(cov_x_r_labeled.correlation_coeffs[0].names.second, covariance_labeled.correlation_coeffs[1].names.second);
+  EXPECT_EQ(cov_x_r_labeled.correlation_coeffs[0].value, covariance_labeled.correlation_coeffs[1].value);
+
+  std::cout << "covariance_labeled\n" << covariance_labeled.toString() << std::endl;
+  std::cout << "covariance_generic_names\n" <<  covariance_generic_names.toString() << std::endl;
+  std::cout << "cov_x_r_generic_names\n" <<  cov_x_r_generic_names.toString() << std::endl;
+  std::cout << "cov_x_r_labeled\n" <<  cov_x_r_labeled.toString() << std::endl;
+
+  // expect exception if number of label vectors is different from number of parameter blocks
+  EXPECT_THROW(rct_optimizations::computeCovariance(problem, param_blocks_x_r, labels_all), rct_optimizations::CovarianceException);
+
+  // expect exception if number of labels for a parameter block is different from the number of parameters in that block in the problem
+  std::vector<std::vector<std::string>> labels_x_r_wrong_size({{"circle_x", "circle_x_extra_entry"}, {"circle_r"}});
+  EXPECT_THROW(rct_optimizations::computeCovariance(problem, param_blocks_x_r, labels_x_r_wrong_size), rct_optimizations::CovarianceException);
+
+  // expect exception with empty parameter block vector
+  EXPECT_THROW(rct_optimizations::computeCovariance(problem, std::vector<const double*>(), labels_all), rct_optimizations::CovarianceException);
+
+  // expect exception with empty labels vector
+  EXPECT_THROW(rct_optimizations::computeCovariance(problem, param_blocks_x_r, std::vector<std::vector<std::string>>()), rct_optimizations::CovarianceException);
 }
 
 int main(int argc, char **argv)

--- a/rct_optimizations/test/covariance_utest.cpp
+++ b/rct_optimizations/test/covariance_utest.cpp
@@ -383,7 +383,7 @@ TEST_F(CircleFitUnit_TwoObsX, FitCircleToTwoPoints)
   EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
 
   // expect covariance.covariance_matrix between Y and R to be close to 1
-  EXPECT_NEAR(abs(result.covariance.correlation_matrix(1, 2)), 1.0, 1e-5);
+  EXPECT_NEAR(fabs(result.covariance.correlation_matrix(1, 2)), 1.0, 1e-5);
 
   // expect covariance between X and R to be somewhat close to 0
   // TODO: fix, not always close to zero due to random initial conditions of problem
@@ -417,7 +417,7 @@ TEST_F(CircleFitUnit_TwoObsY, FitCircleToTwoPoints)
   EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
 
   // expect covariance between X and R to be close to 1
-  EXPECT_NEAR(abs(result.covariance.correlation_matrix(0, 2)), 1.0, 1e-5);
+  EXPECT_NEAR(fabs(result.covariance.correlation_matrix(0, 2)), 1.0, 1e-5);
 
   // expect covariance between Y and R to be somewhat close to 0
   // TODO: fix, not always close to zero due to random initial conditions of problem
@@ -451,9 +451,9 @@ TEST_F(CircleFitUnit_OneObs, FitCircleToOnePoint)
   EXPECT_GE(result.covariance.covariance_matrix(2, 2), 0.0);
 
   // expect magnitudes of all off-diagonal elements to be close to 1
-  EXPECT_NEAR(abs(result.covariance.correlation_matrix(0, 1)), 1.0, 1e-5);
-  EXPECT_NEAR(abs(result.covariance.correlation_matrix(0, 2)), 1.0, 1e-5);
-  EXPECT_NEAR(abs(result.covariance.correlation_matrix(1, 2)), 1.0, 1e-5);
+  EXPECT_NEAR(fabs(result.covariance.correlation_matrix(0, 1)), 1.0, 1e-5);
+  EXPECT_NEAR(fabs(result.covariance.correlation_matrix(0, 2)), 1.0, 1e-5);
+  EXPECT_NEAR(fabs(result.covariance.correlation_matrix(1, 2)), 1.0, 1e-5);
 
   // expect all correlation coefficients to be greater than 0.1
   std::vector<rct_optimizations::NamedParam> outside_thresh = result.covariance.getCorrelationCoeffOutsideThreshold(0.1);

--- a/rct_optimizations/test/dh_chain_kinematic_calibration_utest.cpp
+++ b/rct_optimizations/test/dh_chain_kinematic_calibration_utest.cpp
@@ -150,6 +150,7 @@ TEST_F(DHChainKinematicCalibration, TestCalibrationPerfectGuessPerfectDH)
   }
 
   std::cout << result.covariance.toString() << std::endl;
+  std::cout << result.covariance.printCorrelationCoeffAboveThreshold(0.3) << std::endl;
 }
 
 int main(int argc, char **argv)

--- a/rct_optimizations/test/dh_chain_kinematic_calibration_utest.cpp
+++ b/rct_optimizations/test/dh_chain_kinematic_calibration_utest.cpp
@@ -148,6 +148,8 @@ TEST_F(DHChainKinematicCalibration, TestCalibrationPerfectGuessPerfectDH)
       EXPECT_LT(result.camera_chain_dh_offsets(row, col), 1.0e-15);
     }
   }
+
+  std::cout << result.covariance.toString() << std::endl;
 }
 
 int main(int argc, char **argv)

--- a/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
+++ b/rct_optimizations/test/extrinsic_hand_eye_utest.cpp
@@ -151,12 +151,7 @@ public:
     std::cout << "Base to Target:\n";
     std::cout << t.matrix() << "\n";
 
-    std::cout << "Covariance (camera to wrist):\n";
-    std::cout << r.covariance_camera_mount_to_camera.matrix() << std::endl;
-    std::cout << "Covariance (base to target):\n";
-    std::cout << r.covariance_target_mount_to_target.matrix() << std::endl;
-    std::cout << "Covariance (camera to wrist vs base to target):\n";
-    std::cout << r.covariance_tform_target_to_tform_camera.matrix() << std::endl;
+    std::cout << r.covariance.toString() << std::endl;
   }
 
   Eigen::Isometry3d true_target_mount_to_target;
@@ -188,14 +183,11 @@ TYPED_TEST(HandEyeTest, PerfectInitialConditions)
   EXPECT_TRUE(result.target_mount_to_target.isApprox(this->true_target_mount_to_target, 1e-6));
   EXPECT_TRUE(result.camera_mount_to_camera.isApprox(this->true_camera_mount_to_camera, 1e-6));
 
-  EXPECT_EQ(result.covariance_camera_mount_to_camera.rows(), 6);
-  EXPECT_EQ(result.covariance_camera_mount_to_camera.cols(), 6);
-
-  EXPECT_EQ(result.covariance_target_mount_to_target.rows(), 6);
-  EXPECT_EQ(result.covariance_target_mount_to_target.cols(), 6);
-
-  EXPECT_EQ(result.covariance_tform_target_to_tform_camera.rows(), 6);
-  EXPECT_EQ(result.covariance_tform_target_to_tform_camera.cols(), 6);
+  EXPECT_EQ(result.covariance.covariance_matrix.rows(), 12);
+  EXPECT_EQ(result.covariance.covariance_matrix.cols(), 12);
+  EXPECT_EQ(result.covariance.standard_deviations.size(), 12);
+  EXPECT_EQ(result.covariance.covariances.size(), 66);
+  EXPECT_EQ(result.covariance.correlation_coeffs.size(), 66);
 
   this->printResults(result);
 }
@@ -239,14 +231,11 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions)
     EXPECT_TRUE(result.target_mount_to_target.isApprox(this->true_target_mount_to_target, 1e-6));
     EXPECT_TRUE(result.camera_mount_to_camera.isApprox(this->true_camera_mount_to_camera, 1e-6));
 
-    EXPECT_EQ(result.covariance_camera_mount_to_camera.rows(), 6);
-    EXPECT_EQ(result.covariance_camera_mount_to_camera.cols(), 6);
-
-    EXPECT_EQ(result.covariance_target_mount_to_target.rows(), 6);
-    EXPECT_EQ(result.covariance_target_mount_to_target.cols(), 6);
-
-    EXPECT_EQ(result.covariance_tform_target_to_tform_camera.rows(), 6);
-    EXPECT_EQ(result.covariance_tform_target_to_tform_camera.cols(), 6);
+    EXPECT_EQ(result.covariance.covariance_matrix.rows(), 12);
+    EXPECT_EQ(result.covariance.covariance_matrix.cols(), 12);
+    EXPECT_EQ(result.covariance.standard_deviations.size(), 12);
+    EXPECT_EQ(result.covariance.covariances.size(), 66);
+    EXPECT_EQ(result.covariance.correlation_coeffs.size(), 66);
 
     this->printResults(result);
   }
@@ -299,14 +288,11 @@ TYPED_TEST(HandEyeTest, RandomAroundAnswerInitialConditions_MoreHemispheres)
     EXPECT_TRUE(result.target_mount_to_target.isApprox(this->true_target_mount_to_target, 1e-6));
     EXPECT_TRUE(result.camera_mount_to_camera.isApprox(this->true_camera_mount_to_camera, 1e-6));
 
-    EXPECT_EQ(result.covariance_camera_mount_to_camera.rows(), 6);
-    EXPECT_EQ(result.covariance_camera_mount_to_camera.cols(), 6);
-
-    EXPECT_EQ(result.covariance_target_mount_to_target.rows(), 6);
-    EXPECT_EQ(result.covariance_target_mount_to_target.cols(), 6);
-
-    EXPECT_EQ(result.covariance_tform_target_to_tform_camera.rows(), 6);
-    EXPECT_EQ(result.covariance_tform_target_to_tform_camera.cols(), 6);
+    EXPECT_EQ(result.covariance.covariance_matrix.rows(), 12);
+    EXPECT_EQ(result.covariance.covariance_matrix.cols(), 12);
+    EXPECT_EQ(result.covariance.standard_deviations.size(), 12);
+    EXPECT_EQ(result.covariance.covariances.size(), 66);
+    EXPECT_EQ(result.covariance.correlation_coeffs.size(), 66);
 
     this->printResults(result);
   }

--- a/rct_optimizations/test/extrinsic_multi_static_camera_utest.cpp
+++ b/rct_optimizations/test/extrinsic_multi_static_camera_utest.cpp
@@ -32,6 +32,8 @@ void printResults(const ExtrinsicMultiStaticCameraMovingTargetResult &opt_result
     std::cout << "xyz=\"" << t.translation()(0) << " " << t.translation()(1) << " " << t.translation()(2) << "\"\n";
     std::cout << "rpy=\"" << rpy(2) << "(" << rpy(2) * 180/M_PI << " deg) " << rpy(1) << "(" << rpy(1) * 180/M_PI << " deg) " << rpy(0) << "(" << rpy(0) * 180/M_PI << " deg)\"\n";
   }
+
+  std::cout << opt_result.covariance.toString() << std::endl;
 }
 
 struct Observations
@@ -153,6 +155,14 @@ TEST(ExtrinsicMultiStaticCamera, single_camera)
     EXPECT_TRUE(opt_result.base_to_camera[c].isApprox(base_to_camera[c], 1e-8));
   }
 
+  EXPECT_EQ(opt_result.covariance.covariance_matrix.rows(), 12);
+  EXPECT_EQ(opt_result.covariance.covariance_matrix.cols(), 12);
+  EXPECT_EQ(opt_result.covariance.correlation_matrix.rows(), 12);
+  EXPECT_EQ(opt_result.covariance.correlation_matrix.cols(), 12);
+  EXPECT_EQ(opt_result.covariance.standard_deviations.size(), 12);
+  EXPECT_EQ(opt_result.covariance.covariances.size(), 66);
+  EXPECT_EQ(opt_result.covariance.correlation_coeffs.size(), 66);
+
   printResults(opt_result);
 }
 
@@ -228,12 +238,20 @@ TEST(ExtrinsicMultiStaticCamera, two_cameras)
   ExtrinsicMultiStaticCameraMovingTargetResult opt_result = optimize(problem_def);
 
   EXPECT_TRUE(opt_result.converged);
-  EXPECT_TRUE(opt_result.final_cost_per_obs < 1e-15);
+  EXPECT_LT(opt_result.final_cost_per_obs, 1e-15);
   EXPECT_TRUE(opt_result.wrist_to_target.isApprox(wrist_to_target, 1e-8));
   for (std::size_t c = 0; c < opt_result.base_to_camera.size(); ++c)
   {
     EXPECT_TRUE(opt_result.base_to_camera[c].isApprox(base_to_camera[c], 1e-8));
   }
+
+  EXPECT_EQ(opt_result.covariance.covariance_matrix.rows(), 18);
+  EXPECT_EQ(opt_result.covariance.covariance_matrix.cols(), 18);
+  EXPECT_EQ(opt_result.covariance.correlation_matrix.rows(), 18);
+  EXPECT_EQ(opt_result.covariance.correlation_matrix.cols(), 18);
+  EXPECT_EQ(opt_result.covariance.standard_deviations.size(), 18);
+  EXPECT_EQ(opt_result.covariance.covariances.size(), 153);
+  EXPECT_EQ(opt_result.covariance.correlation_coeffs.size(), 153);
 
   printResults(opt_result);
 }

--- a/rct_optimizations/test/pnp_utest.cpp
+++ b/rct_optimizations/test/pnp_utest.cpp
@@ -26,10 +26,10 @@ void checkCorrelation(const Eigen::MatrixXd& cov)
   }
 }
 
-void printCovariance(const Eigen::MatrixXd& cov)
+void printMatrix(const Eigen::MatrixXd& mat, const std::string& title)
 {
   Eigen::IOFormat fmt(4, 0, " | ", "\n", "|", "|");
-  std::cout << "Covariance:\n" << cov.format(fmt) << std::endl;
+  std::cout << title << ":\n" << mat.format(fmt) << std::endl;
 }
 
 class PnP2DTest : public ::testing::Test
@@ -65,8 +65,8 @@ TEST_F(PnP2DTest, PerfectInitialConditions)
   EXPECT_LT(result.initial_cost_per_obs, 1.0e-15);
   EXPECT_LT(result.final_cost_per_obs, 1.0e-15);
 
-//  checkCorrelation(result.camera_to_target_covariance);
-//  printCovariance(result.camera_to_target_covariance);
+  checkCorrelation(result.covariance.correlation_matrix);
+  printMatrix(result.covariance.correlation_matrix, "Correlation");
 
   std::cout << result.covariance.toString() << std::endl;
 }
@@ -93,7 +93,7 @@ TEST_F(PnP2DTest, PerturbedInitialCondition)
     PnPResult result = optimize(problem);
 
     EXPECT_TRUE(result.converged);
-//    checkCorrelation(result.camera_to_target_covariance);
+    checkCorrelation(result.covariance.correlation_matrix);
 
     // Calculate the difference between the transforms (ideally, an identity matrix)
     Eigen::Isometry3d diff = result.camera_to_target * target_to_camera;
@@ -102,8 +102,6 @@ TEST_F(PnP2DTest, PerturbedInitialCondition)
     pos_acc(diff.translation().norm());
     ori_acc(Eigen::Quaterniond::Identity().angularDistance(Eigen::Quaterniond(diff.linear())));
     residual_acc(result.final_cost_per_obs);
-
-//    std::cout << result.covariance.toString() << std::endl;
   }
 
   // Expect 99% of the outputs (i.e. 3 standard deviations) to be within the corresponding threshold
@@ -139,8 +137,9 @@ TEST_F(PnP2DTest, BadIntrinsicParameters)
   EXPECT_FALSE(result.camera_to_target.isApprox(target_to_camera.inverse(), 1.0e-3));
   EXPECT_GT(result.final_cost_per_obs, 1.0e-3);
 
-//  checkCorrelation(result.camera_to_target_covariance);
-//  printCovariance(result.camera_to_target_covariance);
+  checkCorrelation(result.covariance.correlation_matrix);
+  printMatrix(result.covariance.correlation_matrix, "Correlation");
+  std::cout << result.covariance.toString() << std::endl;
 }
 
 class PnP3DTest : public ::testing::Test
@@ -173,8 +172,11 @@ TEST_F(PnP3DTest, PerfectInitialConditions)
   EXPECT_LT(result.initial_cost_per_obs, 1.0e-15);
   EXPECT_LT(result.final_cost_per_obs, 1.0e-15);
 
-//  checkCorrelation(result.camera_to_target_covariance);
-//  printCovariance(result.camera_to_target_covariance);
+  checkCorrelation(result.covariance.correlation_matrix);
+
+  // BUG: tests pass but nothing is printed
+//  printMatrix(result.covariance.correlation_matrix, "Correlation");
+//  std::cout << result.covariance.toString() << std::endl;
 }
 
 TEST_F(PnP3DTest, PerturbedInitialCondition)
@@ -195,7 +197,7 @@ TEST_F(PnP3DTest, PerturbedInitialCondition)
 
     PnPResult result = optimize(problem);
     EXPECT_TRUE(result.converged);
-//    checkCorrelation(result.camera_to_target_covariance);
+    checkCorrelation(result.covariance.correlation_matrix);
 
     // Calculate the difference between the transforms (ideally, an identity matrix)
     Eigen::Isometry3d diff = result.camera_to_target * target_to_camera;
@@ -204,8 +206,6 @@ TEST_F(PnP3DTest, PerturbedInitialCondition)
     pos_acc(diff.translation().norm());
     ori_acc(Eigen::Quaterniond::Identity().angularDistance(Eigen::Quaterniond(diff.linear())));
     residual_acc(result.final_cost_per_obs);
-
-    std::cout << result.covariance.toString() << std::endl;
   }
 
   // Expect 99% of the outputs (i.e. 3 standard deviations) to be within the corresponding threshold

--- a/rct_optimizations/test/pnp_utest.cpp
+++ b/rct_optimizations/test/pnp_utest.cpp
@@ -64,8 +64,11 @@ TEST_F(PnP2DTest, PerfectInitialConditions)
   EXPECT_TRUE(result.camera_to_target.isApprox(target_to_camera.inverse()));
   EXPECT_LT(result.initial_cost_per_obs, 1.0e-15);
   EXPECT_LT(result.final_cost_per_obs, 1.0e-15);
-  checkCorrelation(result.camera_to_target_covariance);
-  printCovariance(result.camera_to_target_covariance);
+
+//  checkCorrelation(result.camera_to_target_covariance);
+//  printCovariance(result.camera_to_target_covariance);
+
+  std::cout << result.covariance.toString() << std::endl;
 }
 
 TEST_F(PnP2DTest, PerturbedInitialCondition)
@@ -90,7 +93,7 @@ TEST_F(PnP2DTest, PerturbedInitialCondition)
     PnPResult result = optimize(problem);
 
     EXPECT_TRUE(result.converged);
-    checkCorrelation(result.camera_to_target_covariance);
+//    checkCorrelation(result.camera_to_target_covariance);
 
     // Calculate the difference between the transforms (ideally, an identity matrix)
     Eigen::Isometry3d diff = result.camera_to_target * target_to_camera;
@@ -99,12 +102,15 @@ TEST_F(PnP2DTest, PerturbedInitialCondition)
     pos_acc(diff.translation().norm());
     ori_acc(Eigen::Quaterniond::Identity().angularDistance(Eigen::Quaterniond(diff.linear())));
     residual_acc(result.final_cost_per_obs);
+
+//    std::cout << result.covariance.toString() << std::endl;
   }
 
   // Expect 99% of the outputs (i.e. 3 standard deviations) to be within the corresponding threshold
   EXPECT_LT(ba::mean(pos_acc) + 3 * std::sqrt(ba::variance(pos_acc)), 1.0e-7);
   EXPECT_LT(ba::mean(ori_acc) + 3 * std::sqrt(ba::variance(ori_acc)), 1.0e-6);
   EXPECT_LT(ba::mean(residual_acc) + 3 * std::sqrt(ba::variance(residual_acc)), 1.0e-10);
+
 }
 
 TEST_F(PnP2DTest, BadIntrinsicParameters)
@@ -132,8 +138,9 @@ TEST_F(PnP2DTest, BadIntrinsicParameters)
   EXPECT_TRUE(result.converged);
   EXPECT_FALSE(result.camera_to_target.isApprox(target_to_camera.inverse(), 1.0e-3));
   EXPECT_GT(result.final_cost_per_obs, 1.0e-3);
-  checkCorrelation(result.camera_to_target_covariance);
-  printCovariance(result.camera_to_target_covariance);
+
+//  checkCorrelation(result.camera_to_target_covariance);
+//  printCovariance(result.camera_to_target_covariance);
 }
 
 class PnP3DTest : public ::testing::Test
@@ -165,8 +172,9 @@ TEST_F(PnP3DTest, PerfectInitialConditions)
   EXPECT_TRUE(result.camera_to_target.isApprox(target_to_camera.inverse()));
   EXPECT_LT(result.initial_cost_per_obs, 1.0e-15);
   EXPECT_LT(result.final_cost_per_obs, 1.0e-15);
-  checkCorrelation(result.camera_to_target_covariance);
-  printCovariance(result.camera_to_target_covariance);
+
+//  checkCorrelation(result.camera_to_target_covariance);
+//  printCovariance(result.camera_to_target_covariance);
 }
 
 TEST_F(PnP3DTest, PerturbedInitialCondition)
@@ -187,7 +195,7 @@ TEST_F(PnP3DTest, PerturbedInitialCondition)
 
     PnPResult result = optimize(problem);
     EXPECT_TRUE(result.converged);
-    checkCorrelation(result.camera_to_target_covariance);
+//    checkCorrelation(result.camera_to_target_covariance);
 
     // Calculate the difference between the transforms (ideally, an identity matrix)
     Eigen::Isometry3d diff = result.camera_to_target * target_to_camera;
@@ -196,6 +204,8 @@ TEST_F(PnP3DTest, PerturbedInitialCondition)
     pos_acc(diff.translation().norm());
     ori_acc(Eigen::Quaterniond::Identity().angularDistance(Eigen::Quaterniond(diff.linear())));
     residual_acc(result.final_cost_per_obs);
+
+    std::cout << result.covariance.toString() << std::endl;
   }
 
   // Expect 99% of the outputs (i.e. 3 standard deviations) to be within the corresponding threshold

--- a/rct_optimizations/test/src/utilities.cpp
+++ b/rct_optimizations/test/src/utilities.cpp
@@ -54,12 +54,12 @@ DHChain createABBIRB2400()
   t5 << 0.0, 0.0, 0.0, -M_PI / 2.0;
   t6 << 0.085, M_PI, 0.0, 0.0;
 
-  joints.push_back(DHTransform(t1, DHJointType::REVOLUTE));
-  joints.push_back(DHTransform(t2, DHJointType::REVOLUTE));
-  joints.push_back(DHTransform(t3, DHJointType::REVOLUTE));
-  joints.push_back(DHTransform(t4, DHJointType::REVOLUTE));
-  joints.push_back(DHTransform(t5, DHJointType::REVOLUTE));
-  joints.push_back(DHTransform(t6, DHJointType::REVOLUTE));
+  joints.push_back(DHTransform(t1, DHJointType::REVOLUTE, "j1"));
+  joints.push_back(DHTransform(t2, DHJointType::REVOLUTE, "j2"));
+  joints.push_back(DHTransform(t3, DHJointType::REVOLUTE, "j3"));
+  joints.push_back(DHTransform(t4, DHJointType::REVOLUTE, "j4"));
+  joints.push_back(DHTransform(t5, DHJointType::REVOLUTE, "j5"));
+  joints.push_back(DHTransform(t6, DHJointType::REVOLUTE, "j6"));
 
   return DHChain(joints);
 }


### PR DESCRIPTION
Initial effort at formatting covariance results in an easier-to-use format than Eigen matrices.

- Define a new `NamedParam` type, which describes values that are functions of one or two named parameters.
- Create a `CovarianceResult` struct, which contains vectors of `NamedParam` for the outputs of covariance and correlation calculations. The struct has functions to format itself as a string, and to identify which of its `NamedParam`s have values outside a specified threshold.
- Add new covariance calculation functions which take `string` names as inputs, which allows returning a `CovarianceResult` rather than an Eigen matrix.
- Change the optimizations that were representing covariance matrices as `Eigen::MatrixXd` to instead use `CovarianceResult`.

TODO:

- [x] Fix tests that were disabled by this change
- [x] Add new tests comparing `CovarianceResult` output to Eigen matrix output, to make sure they match