### PR TITLE
PnP Optimization Fix

### DIFF
--- a/rct_optimizations/src/rct_optimizations/pnp.cpp
+++ b/rct_optimizations/src/rct_optimizations/pnp.cpp
@@ -28,7 +28,7 @@ struct SolvePnPCostFunc
     camera_to_target = Eigen::Translation<T, 3>(t) * q;
 
     // Transform points into camera coordinates
-    Vector3 camera_pt = camera_to_target.inverse() * in_target_.cast<T>();
+    Vector3 camera_pt = camera_to_target * in_target_.cast<T>();
 
     Vector2 xy_image = projectPoint(intr_, camera_pt);
 

--- a/rct_optimizations/test/pnp_utest.cpp
+++ b/rct_optimizations/test/pnp_utest.cpp
@@ -60,7 +60,7 @@ TEST(PNP_2D, PerturbedInitialCondition)
   PnPResult result = optimize(problem);
   EXPECT_TRUE(result.converged);
   EXPECT_TRUE(result.camera_to_target.isApprox(target_to_camera.inverse(), 1.0e-8));
-  EXPECT_LT(result.final_cost_per_obs, 1.0e-15);
+  EXPECT_LT(result.final_cost_per_obs, 1.0e-14);
 }
 
 TEST(PNP_2D, BadIntrinsicParameters)


### PR DESCRIPTION
This PR fixes incorrect transformation math from #54 in the projection of target points into the camera frame. It also corrects the `camera_to_target` transform in the unit test, which actually represented the transform from the target to camera