### PR TITLE
DH Chain Base Offset

### DIFF
--- a/rct_optimizations/include/rct_optimizations/dh_chain.h
+++ b/rct_optimizations/include/rct_optimizations/dh_chain.h
@@ -201,9 +201,9 @@ public:
 
 protected:
   /** @brief The DH transforms that make up the chain */
-  const std::vector<DHTransform> transforms_;
+  std::vector<DHTransform> transforms_;
   /** @brief Fixed transform offset to the beginning of the chain */
-  const Eigen::Isometry3d base_offset_;
+  Eigen::Isometry3d base_offset_;
 };
 
 } // namespace rct_optimizations

--- a/rct_optimizations/include/rct_optimizations/dh_chain.h
+++ b/rct_optimizations/include/rct_optimizations/dh_chain.h
@@ -139,12 +139,27 @@ public:
    * @param joint_values - The joint values with which to calculate the forward kinematics (size: [<= @ref dof()])
    * @param offsets - The DH parameter offsets to apply when calculating the forward kinematics (size: [@ref dof() x 4])
    * @return
-   * @throws Exception if the size of the joint values is larger than the number of DH transforms in the chain
+   * @throws Exception if the size of @ref joint_values is larger than the number of DH transforms in the chain
+   * or if the size of @ref joint_values is larger than the rows of DH offsets
    */
   template<typename T>
   Isometry3<T> getFK(const Eigen::Matrix<T, Eigen::Dynamic, 1>& joint_values,
                      const Eigen::Matrix<T, Eigen::Dynamic, 4>& offsets) const
   {
+    if (joint_values.size() > dof())
+    {
+      std::stringstream ss;
+      ss << "Joint values size (" << joint_values.size() << ") is larger than the chain DoF (" << dof() << ")";
+      throw std::runtime_error(ss.str());
+    }
+    else if (joint_values.size() > offsets.rows())
+    {
+      std::stringstream ss;
+      ss << "Joint values size (" << joint_values.size() << ") is larger than the rows of DH offsets ("
+         << offsets.rows() << ")";
+      throw std::runtime_error(ss.str());
+    }
+
     Isometry3<T> transform(base_offset_.cast<T>());
     for (Eigen::Index i = 0; i < joint_values.size(); ++i)
     {

--- a/rct_optimizations/src/rct_optimizations/dh_chain.cpp
+++ b/rct_optimizations/src/rct_optimizations/dh_chain.cpp
@@ -40,8 +40,10 @@ std::array<std::string, 4> DHTransform::getParamLabels() const
 
 // DH Chain
 
-DHChain::DHChain(std::vector<DHTransform> transforms)
+DHChain::DHChain(std::vector<DHTransform> transforms,
+                 const Eigen::Isometry3d& base_offset)
   : transforms_(std::move(transforms))
+  , base_offset_(base_offset)
 {
 }
 

--- a/rct_optimizations/test/dh_parameter_utest.cpp
+++ b/rct_optimizations/test/dh_parameter_utest.cpp
@@ -58,7 +58,7 @@ TEST(DHChain, FKWithJointSubsetTest)
   {
     EXPECT_NO_THROW(robot.getFK<double>(Eigen::VectorXd::Zero(i)));
   }
-  EXPECT_THROW(robot.getFK<double>(Eigen::VectorXd::Zero(robot.dof() + 1)), std::out_of_range);
+  EXPECT_THROW(robot.getFK<double>(Eigen::VectorXd::Zero(robot.dof() + 1)), std::runtime_error);
 }
 
 TEST(DHChain, generateObservations3D)

--- a/rct_optimizations/test/include/rct_optimizations_tests/utilities.h
+++ b/rct_optimizations/test/include/rct_optimizations_tests/utilities.h
@@ -89,6 +89,12 @@ DHChain createChain(const Eigen::MatrixXd &dh, const std::vector<DHJointType> &j
 DHChain createABBIRB2400();
 
 /**
+ * @brief Creates a DH parameter-based robot representation of a generic two-axis part positioner with arbitrary base offset
+ * @return
+ */
+DHChain createTwoAxisPositioner();
+
+/**
  * @brief Creates a kinematic chain whose DH parameters are pertubed with Gaussian noise relative to the reference kinematic chain
  * @param in - reference kinematic chain
  * @param stddev - standard deviation to apply to all DH parameters individually

--- a/rct_optimizations/test/src/utilities.cpp
+++ b/rct_optimizations/test/src/utilities.cpp
@@ -57,26 +57,58 @@ DHChain createChain(const Eigen::MatrixXd &dh, const std::vector<DHJointType> &j
 
 DHChain createABBIRB2400()
 {
-  std::vector<DHTransform> joints;
-  joints.reserve(6);
+  std::vector<DHTransform> transforms;
+  transforms.reserve(6);
 
-  Eigen::Vector4d t1, t2, t3, t4, t5, t6;
+  Eigen::Vector4d p1, p2, p3, p4, p5, p6;
 
-  t1 << 0.615, 0.0, 0.100, -M_PI / 2.0;
-  t2 << 0.0, -M_PI / 2.0, 0.705, 0.0;
-  t3 << 0.0, 0.0, 0.135, -M_PI / 2.0;
-  t4 << 0.755, 0.0, 0.0, M_PI / 2.0;
-  t5 << 0.0, 0.0, 0.0, -M_PI / 2.0;
-  t6 << 0.085, M_PI, 0.0, 0.0;
+  p1 << 0.615, 0.0, 0.100, -M_PI / 2.0;
+  p2 << 0.0, -M_PI / 2.0, 0.705, 0.0;
+  p3 << 0.0, 0.0, 0.135, -M_PI / 2.0;
+  p4 << 0.755, 0.0, 0.0, M_PI / 2.0;
+  p5 << 0.0, 0.0, 0.0, -M_PI / 2.0;
+  p6 << 0.085, M_PI, 0.0, 0.0;
 
-  joints.push_back(DHTransform(t1, DHJointType::REVOLUTE, "j1"));
-  joints.push_back(DHTransform(t2, DHJointType::REVOLUTE, "j2"));
-  joints.push_back(DHTransform(t3, DHJointType::REVOLUTE, "j3"));
-  joints.push_back(DHTransform(t4, DHJointType::REVOLUTE, "j4"));
-  joints.push_back(DHTransform(t5, DHJointType::REVOLUTE, "j5"));
-  joints.push_back(DHTransform(t6, DHJointType::REVOLUTE, "j6"));
+  transforms.emplace_back(p1, DHJointType::REVOLUTE, "j1");
+  transforms.emplace_back(p2, DHJointType::REVOLUTE, "j2");
+  transforms.emplace_back(p3, DHJointType::REVOLUTE, "j3");
+  transforms.emplace_back(p4, DHJointType::REVOLUTE, "j4");
+  transforms.emplace_back(p5, DHJointType::REVOLUTE, "j5");
+  transforms.emplace_back(p6, DHJointType::REVOLUTE, "j6");
 
-  return DHChain(joints);
+  return DHChain(transforms);
+}
+
+DHChain createTwoAxisPositioner()
+{
+  std::vector<DHTransform> transforms;
+  transforms.reserve(2);
+
+  Eigen::Vector4d p1, p2;
+  p1 << 0.0, 0.0, 0.0, -M_PI / 2.0;
+  p2 << -0.475, -M_PI / 2.0, 0.0, 0.0;
+
+  // Add the first DH transform
+  {
+    DHTransform t(p1, DHJointType::REVOLUTE, "j1");
+    t.max = M_PI;
+    t.min = -M_PI;
+    transforms.push_back(t);
+  }
+  // Add the second DH transform
+  {
+    DHTransform dh_transform(p2, DHJointType::REVOLUTE, "j2");
+    dh_transform.max = 2.0 * M_PI;
+    dh_transform.min = -2.0 * M_PI;
+    transforms.push_back(dh_transform);
+  }
+
+  // Set an arbitrary base offset
+  Eigen::Isometry3d base_offset(Eigen::Isometry3d::Identity());
+  base_offset.translate(Eigen::Vector3d(2.2, 0.0, 1.6));
+  base_offset.rotate(Eigen::AngleAxisd(M_PI / 2.0, Eigen::Vector3d::UnitX()));
+
+  return DHChain(transforms, base_offset);
 }
 
 DHChain perturbDHChain(const DHChain &in, const double stddev)


### PR DESCRIPTION
This PR removes the `FIXED` DH transform type in favor of specifying a fixed base offset transform from the desired base frame to the first DH link.

This PR also adds a DH chain representation of a two-axis positioner for testing of the kinematic calibration algorithms (see image below). It utilizes the fixed base offset to avoid specifying a fixed DH transform in the chain.

![image](https://user-images.githubusercontent.com/18411310/88313623-656f8b80-ccd9-11ea-99f2-64490f57ea6d.png)
