### PR TITLE
Target Loading Update

### DIFF
--- a/rct_examples/src/examples/camera_on_wrist.cpp
+++ b/rct_examples/src/examples/camera_on_wrist.cpp
@@ -113,6 +113,7 @@ int extrinsicWristCameraCalibration()
     obs.correspondence_set.reserve(maybe_obs->size());
 
     // And loop over each detected dot:
+    const std::vector<Eigen::Vector3d> target_points = target.createPoints();
     for (std::size_t j = 0; j < maybe_obs->size(); ++j)
     {
       // The 'target.points' data structure and the observation vector returned by
@@ -120,7 +121,7 @@ int extrinsicWristCameraCalibration()
       // respresents the same dot!
       rct_optimizations::Correspondence2D3D pair;
       pair.in_image = maybe_obs->at(j); // The obs finder and target define their points in the same order!
-      pair.in_target = target.points[j];
+      pair.in_target = target_points[j];
       obs.correspondence_set.push_back(pair);
     }
 

--- a/rct_examples/src/tools/camera_intrinsic_calibration_validation.cpp
+++ b/rct_examples/src/tools/camera_intrinsic_calibration_validation.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
       obs.to_target_mount = Eigen::Isometry3d::Identity();
 
       //// And finally add that to the problem
-      obs.correspondence_set = getCorrespondenceSet(*maybe_obs, target.points);
+      obs.correspondence_set = getCorrespondenceSet(*maybe_obs, target.createPoints());
 
       observations.push_back(obs);
     }

--- a/rct_examples/src/tools/camera_on_wrist_extrinsic.cpp
+++ b/rct_examples/src/tools/camera_on_wrist_extrinsic.cpp
@@ -27,7 +27,7 @@ static void reproject(const Eigen::Isometry3d& wrist_to_camera, const Eigen::Iso
   // We want to compute the "positional error" as well
   // So first we compute the "camera to target" transform based on the calibration...
   Eigen::Isometry3d camera_to_target = (obs.to_camera_mount * wrist_to_camera).inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr, target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr, target.createPoints());
 
   cv::Mat frame = image.clone();
   drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), frame);
@@ -139,7 +139,7 @@ int main(int argc, char** argv)
     obs.to_target_mount = Eigen::Isometry3d::Identity();
 
     //// And finally add that to the problem
-    obs.correspondence_set = getCorrespondenceSet(*maybe_obs, target.points);
+    obs.correspondence_set = getCorrespondenceSet(*maybe_obs, target.createPoints());
 
     problem_def.observations.push_back(obs);
   }

--- a/rct_examples/src/tools/camera_on_wrist_extrinsic.cpp
+++ b/rct_examples/src/tools/camera_on_wrist_extrinsic.cpp
@@ -1,6 +1,7 @@
 // Utilities for loading data sets and calib parameters from YAML files via ROS
 #include "rct_ros_tools/data_set.h"
 #include "rct_ros_tools/parameter_loaders.h"
+#include "rct_ros_tools/target_loaders.h"
 #include "rct_ros_tools/print_utils.h"
 // To find 2D  observations from images
 #include <rct_image_tools/image_observation_finder.h>
@@ -15,32 +16,36 @@
 #include <opencv2/imgproc.hpp>
 #include <rct_optimizations/ceres_math_utilities.h>
 
+using namespace rct_optimizations;
+using namespace rct_image_tools;
+using namespace rct_ros_tools;
+
 static void reproject(const Eigen::Isometry3d& wrist_to_camera, const Eigen::Isometry3d& base_to_target,
-                      const rct_optimizations::Observation2D3D& obs, const rct_optimizations::CameraIntrinsics& intr,
-                      const rct_image_tools::ModifiedCircleGridTarget& target, const cv::Mat& image)
+                      const Observation2D3D& obs, const CameraIntrinsics& intr,
+                      const ModifiedCircleGridTarget& target, const cv::Mat& image)
 {
   // We want to compute the "positional error" as well
   // So first we compute the "camera to target" transform based on the calibration...
   Eigen::Isometry3d camera_to_target = (obs.to_camera_mount * wrist_to_camera).inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections = rct_image_tools::getReprojections(camera_to_target, intr, target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr, target.points);
 
   cv::Mat frame = image.clone();
-  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), frame);
+  drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), frame);
 
-  rct_optimizations::PnPProblem pb;
+  PnPProblem pb;
   pb.camera_to_target_guess = camera_to_target;
   pb.correspondences = obs.correspondence_set;
   pb.intr = intr;
-  rct_optimizations::PnPResult r = rct_optimizations::optimize(pb);
+  PnPResult r = optimize(pb);
 
-  rct_ros_tools::printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
+  printNewLine();
 
-  rct_ros_tools::printTransform(r.camera_to_target, "Camera", "Target", "PNP");
-  rct_ros_tools::printNewLine();
+  printTransform(r.camera_to_target, "Camera", "Target", "PNP");
+  printNewLine();
 
-  rct_ros_tools::printTransformDiff(camera_to_target, r.camera_to_target, "Camera", "Target", "PNP DIFF");
-  rct_ros_tools::printNewLine();
+  printTransformDiff(camera_to_target, r.camera_to_target, "Camera", "Target", "PNP DIFF");
+  printNewLine();
 
   cv::imshow("repr", frame);
   cv::waitKey();
@@ -59,45 +64,45 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  rct_image_tools::ModifiedCircleGridTarget target;
-  if (!rct_ros_tools::loadTarget(pnh, "target_definition", target))
+  ModifiedCircleGridTarget target;
+  if (!TargetLoader<ModifiedCircleGridTarget>::load(pnh, "target_definition", target))
   {
     ROS_WARN_STREAM("Unable to load target from the 'target_definition' parameter struct");
     return 1;
   }
 
-  rct_optimizations::CameraIntrinsics intr;
-  if (!rct_ros_tools::loadIntrinsics(pnh, "intrinsics", intr))
+  CameraIntrinsics intr;
+  if (!loadIntrinsics(pnh, "intrinsics", intr))
   {
     ROS_WARN_STREAM("Unable to load camera intrinsics from the 'intrinsics' parameter struct");
     return 1;
   }
 
   // Attempt to load the data set via the data record yaml file:
-  boost::optional<rct_ros_tools::ExtrinsicDataSet> maybe_data_set = rct_ros_tools::parseFromFile(data_path);
+  boost::optional<ExtrinsicDataSet> maybe_data_set = parseFromFile(data_path);
   if (!maybe_data_set)
   {
     ROS_ERROR_STREAM("Failed to parse data set from path = " << data_path);
     return 2;
   }
   // We know it exists, so define a helpful alias
-  const rct_ros_tools::ExtrinsicDataSet& data_set = *maybe_data_set;
+  const ExtrinsicDataSet& data_set = *maybe_data_set;
 
   // Lets create a class that will search for the target in our raw images.
-  rct_image_tools::ModifiedCircleGridObservationFinder obs_finder(target);
+  ModifiedCircleGridObservationFinder obs_finder(target);
 
   // Now we create our calibration problem
-  rct_optimizations::ExtrinsicHandEyeProblem2D3D problem_def;
+  ExtrinsicHandEyeProblem2D3D problem_def;
   problem_def.intr = intr; // Set the camera properties
 
   // Our 'base to camera guess': A camera off to the side, looking at a point centered in front of the robot
-  if (!rct_ros_tools::loadPose(pnh, "base_to_target_guess", problem_def.target_mount_to_target_guess))
+  if (!loadPose(pnh, "base_to_target_guess", problem_def.target_mount_to_target_guess))
   {
     ROS_WARN_STREAM("Unable to load guess for base to camera from the 'base_to_target_guess' parameter struct");
     return 1;
   }
 
-  if (!rct_ros_tools::loadPose(pnh, "wrist_to_camera_guess", problem_def.camera_mount_to_camera_guess))
+  if (!loadPose(pnh, "wrist_to_camera_guess", problem_def.camera_mount_to_camera_guess))
   {
     ROS_WARN_STREAM("Unable to load guess for wrist to target from the 'wrist_to_camera_guess' parameter struct");
     return 1;
@@ -125,7 +130,7 @@ int main(int argc, char** argv)
       cv::waitKey();
     }
 
-    rct_optimizations::Observation2D3D obs;
+    Observation2D3D obs;
     obs.correspondence_set.reserve(maybe_obs->size());
 
     // So for each image we need to:
@@ -134,32 +139,32 @@ int main(int argc, char** argv)
     obs.to_target_mount = Eigen::Isometry3d::Identity();
 
     //// And finally add that to the problem
-    obs.correspondence_set = rct_image_tools::getCorrespondenceSet(*maybe_obs, target.points);
+    obs.correspondence_set = getCorrespondenceSet(*maybe_obs, target.points);
 
     problem_def.observations.push_back(obs);
   }
 
   // Now we have a defined problem, run optimization:
-  rct_optimizations::ExtrinsicHandEyeResult opt_result = rct_optimizations::optimize(problem_def);
+  ExtrinsicHandEyeResult opt_result = optimize(problem_def);
 
   // Report results
-  rct_ros_tools::printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
+  printNewLine();
 
   Eigen::Isometry3d c = opt_result.camera_mount_to_camera;
-  rct_ros_tools::printTransform(c, "Wrist", "Camera", "WRIST TO CAMERA");
-  rct_ros_tools::printNewLine();
+  printTransform(c, "Wrist", "Camera", "WRIST TO CAMERA");
+  printNewLine();
 
   Eigen::Isometry3d t = opt_result.target_mount_to_target;
-  rct_ros_tools::printTransform(t, "Base", "Target", "BASE TO TARGET");
-  rct_ros_tools::printNewLine();
+  printTransform(t, "Base", "Target", "BASE TO TARGET");
+  printNewLine();
 
   std::cout << opt_result.covariance.toString() << std::endl;
 
-  rct_ros_tools::printTitle("REPROJECTION ERROR");
+  printTitle("REPROJECTION ERROR");
   for (std::size_t i = 0; i < data_set.images.size(); ++i)
   {
-    rct_ros_tools::printTitle("REPROJECT IMAGE " + std::to_string(i));
+    printTitle("REPROJECT IMAGE " + std::to_string(i));
     reproject(opt_result.camera_mount_to_camera,
               opt_result.target_mount_to_target,
               problem_def.observations[i],

--- a/rct_examples/src/tools/intrinsic_calibration.cpp
+++ b/rct_examples/src/tools/intrinsic_calibration.cpp
@@ -124,7 +124,7 @@ int main(int argc, char** argv)
     cv::imshow("points", obs_finder.drawObservations(data_set.images[i], *maybe_obs));
     cv::waitKey();
 
-    problem_def.image_observations.push_back(getCorrespondenceSet(*maybe_obs, target.points));
+    problem_def.image_observations.push_back(getCorrespondenceSet(*maybe_obs, target.createPoints()));
   }
 
   // Run optimization

--- a/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
@@ -30,7 +30,7 @@ static void reproject(const Eigen::Isometry3d& base_to_target,
 {
 
   Eigen::Isometry3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr[0], target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr[0], target.createPoints());
 
   cv::Mat before_frame = image.clone();
   drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
@@ -56,7 +56,7 @@ static void reproject(const Eigen::Isometry3d& base_to_target,
   printTransformDiff(camera_to_target, result_camera_to_target, "Camera 0", "Target", "PNP DIFF");
   printNewLine();
 
-  reprojections = getReprojections(result_camera_to_target, intr[0], target.points);
+  reprojections = getReprojections(result_camera_to_target, intr[0], target.createPoints());
   cv::Mat after_frame = image.clone();
   drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
 

--- a/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_extrinsic.cpp
@@ -1,6 +1,7 @@
 // Utilities for loading data sets and calib parameters from YAML files via ROS
 #include "rct_ros_tools/data_set.h"
 #include "rct_ros_tools/parameter_loaders.h"
+#include "rct_ros_tools/target_loaders.h"
 #include "rct_ros_tools/print_utils.h"
 
 // To find 2D  observations from images
@@ -16,44 +17,48 @@
 #include <rct_optimizations/ceres_math_utilities.h>
 #include <rct_optimizations/experimental/multi_camera_pnp.h>
 
+using namespace rct_optimizations;
+using namespace rct_image_tools;
+using namespace rct_ros_tools;
+
 static void reproject(const Eigen::Isometry3d& base_to_target,
                       const std::vector<Eigen::Isometry3d>& base_to_camera,
-                      const std::vector<rct_optimizations::CameraIntrinsics>& intr,
-                      const rct_image_tools::ModifiedCircleGridTarget& target,
+                      const std::vector<CameraIntrinsics>& intr,
+                      const ModifiedCircleGridTarget& target,
                       const cv::Mat& image,
-                      const std::vector<rct_optimizations::Correspondence2D3D::Set>& corr)
+                      const std::vector<Correspondence2D3D::Set>& corr)
 {
 
   Eigen::Isometry3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections = rct_image_tools::getReprojections(camera_to_target, intr[0], target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr[0], target.points);
 
   cv::Mat before_frame = image.clone();
-  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
+  drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
 
-  rct_optimizations::MultiCameraPnPProblem pb;
+  MultiCameraPnPProblem pb;
   pb.base_to_camera = base_to_camera;
   pb.base_to_target_guess = base_to_target;
   pb.image_observations = corr;
   pb.intr = intr;
 
-  rct_optimizations::MultiCameraPnPResult r = rct_optimizations::optimize(pb);
+  MultiCameraPnPResult r = optimize(pb);
   // Report results
-  rct_ros_tools::printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
+  printNewLine();
 
-  rct_ros_tools::printTransform(camera_to_target, "Camera 0", "Target", "CAMERA 0 TO TARGET");
-  rct_ros_tools::printNewLine();
+  printTransform(camera_to_target, "Camera 0", "Target", "CAMERA 0 TO TARGET");
+  printNewLine();
 
   Eigen::Isometry3d result_camera_to_target = base_to_camera[0].inverse() * r.base_to_target;
-  rct_ros_tools::printTransform(result_camera_to_target, "Camera 0", "Target", "PNP");
-  rct_ros_tools::printNewLine();
+  printTransform(result_camera_to_target, "Camera 0", "Target", "PNP");
+  printNewLine();
 
-  rct_ros_tools::printTransformDiff(camera_to_target, result_camera_to_target, "Camera 0", "Target", "PNP DIFF");
-  rct_ros_tools::printNewLine();
+  printTransformDiff(camera_to_target, result_camera_to_target, "Camera 0", "Target", "PNP DIFF");
+  printNewLine();
 
-  reprojections = rct_image_tools::getReprojections(result_camera_to_target, intr[0], target.points);
+  reprojections = getReprojections(result_camera_to_target, intr[0], target.points);
   cv::Mat after_frame = image.clone();
-  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
+  drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
 
   cv::imshow("repr_before", before_frame);
   cv::imshow("repr_after", after_frame);
@@ -73,10 +78,10 @@ int main(int argc, char** argv)
   }
   std::size_t num_of_cameras = camera_count;
 
-  rct_optimizations::ExtrinsicMultiStaticCameraMovingTargetProblem problem_def;
+  ExtrinsicMultiStaticCameraMovingTargetProblem problem_def;
   std::vector<std::string> data_path;
   std::string target_path;
-  std::vector<rct_ros_tools::ExtrinsicDataSet> maybe_data_set;
+  std::vector<ExtrinsicDataSet> maybe_data_set;
 
   data_path.resize(num_of_cameras);
   maybe_data_set.resize(num_of_cameras);
@@ -96,7 +101,7 @@ int main(int argc, char** argv)
     }
 
     // Attempt to load the data set from the specified path
-    boost::optional<rct_ros_tools::ExtrinsicDataSet> data_set = *rct_ros_tools::parseFromFile(data_path[c]);
+    boost::optional<ExtrinsicDataSet> data_set = *parseFromFile(data_path[c]);
     if (!data_set)
     {
       ROS_ERROR_STREAM("Failed to parse data set from path = " << data_path[c]);
@@ -111,7 +116,7 @@ int main(int argc, char** argv)
     problem_def.intr[c].fy() = 1408.0;
     problem_def.intr[c].cx() = 807.2;
     problem_def.intr[c].cy() = 615.0;
-    if (!rct_ros_tools::loadIntrinsics(pnh, param_name, problem_def.intr[c]))
+    if (!loadIntrinsics(pnh, param_name, problem_def.intr[c]))
     {
       ROS_WARN("Unable to load camera intrinsics from the '%s' parameter struct", param_name.c_str());
       return 1;
@@ -119,14 +124,14 @@ int main(int argc, char** argv)
 
     param_name = param_base + "base_to_camera_guess";
     // Our 'base to camera guess': A camera off to the side, looking at a point centered in front of the robot
-    if (!rct_ros_tools::loadPose(pnh, param_name, problem_def.base_to_camera_guess[c]))
+    if (!loadPose(pnh, param_name, problem_def.base_to_camera_guess[c]))
     {
       ROS_WARN("Unable to load guess for base to camera from the '%s' parameter struct", param_name.c_str());
       return 1;
     }
   }
 
-  if (!rct_ros_tools::loadPose(pnh, "wrist_to_target_guess", problem_def.wrist_to_target_guess))
+  if (!loadPose(pnh, "wrist_to_target_guess", problem_def.wrist_to_target_guess))
   {
     ROS_WARN_STREAM("Unable to load guess for wrist to target from the 'wrist_to_target_guess' parameter struct");
     return 1;
@@ -140,17 +145,17 @@ int main(int argc, char** argv)
 
   // Load target definition from parameter server. Target will get
   // reset if such a parameter was set.
-  rct_image_tools::ModifiedCircleGridTarget target;
-  if (!rct_ros_tools::loadTarget(target_path, target))
+  ModifiedCircleGridTarget target;
+  if (!TargetLoader<ModifiedCircleGridTarget>::load(target_path, target))
   {
     ROS_WARN_STREAM("Unable to load target file from the 'target_path' parameter");
     return 1;
   }
 
   // Lets create a class that will search for the target in our raw images.
-  rct_image_tools::ModifiedCircleGridObservationFinder obs_finder(target);
+  ModifiedCircleGridObservationFinder obs_finder(target);
 
-  rct_ros_tools::ExtrinsicCorrespondenceDataSet corr_data_set(maybe_data_set, obs_finder, true);
+  ExtrinsicCorrespondenceDataSet corr_data_set(maybe_data_set, obs_finder, true);
 
   // build problem
   for (std::size_t c = 0; c < corr_data_set.getCameraCount(); ++c)
@@ -159,7 +164,7 @@ int main(int argc, char** argv)
     {
       if (corr_data_set.foundCorrespondence(c, i))
       {
-        const rct_ros_tools::ExtrinsicDataSet& data_set = maybe_data_set[c];
+        const ExtrinsicDataSet& data_set = maybe_data_set[c];
         problem_def.wrist_poses[c].push_back(data_set.tool_poses[i]);
         problem_def.image_observations[c].push_back(corr_data_set.getCorrespondenceSet(c, i));
       }
@@ -167,38 +172,38 @@ int main(int argc, char** argv)
   }
 
   // Run optimization
-  rct_optimizations::ExtrinsicMultiStaticCameraMovingTargetResult
-      opt_result = rct_optimizations::optimize(problem_def);
+  ExtrinsicMultiStaticCameraMovingTargetResult
+      opt_result = optimize(problem_def);
 
   // Report results
-  rct_ros_tools::printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
+  printNewLine();
 
   Eigen::Isometry3d t = opt_result.wrist_to_target;
-  rct_ros_tools::printTransform(t, "Wrist", "Target", "WRIST TO TARGET");
-  rct_ros_tools::printNewLine();
+  printTransform(t, "Wrist", "Target", "WRIST TO TARGET");
+  printNewLine();
 
   for (std::size_t c = 0; c < num_of_cameras; ++c)
   {
     // Load the data set path from ROS param
     std::string param_base = "camera_" + std::to_string(c);
     t = opt_result.base_to_camera[c];
-    rct_ros_tools::printTransform(t, "Base", " Camera (" + param_base + ")", "BASE TO CAMERA (" + param_base + ")");
-    rct_ros_tools::printNewLine();
+    printTransform(t, "Base", " Camera (" + param_base + ")", "BASE TO CAMERA (" + param_base + ")");
+    printNewLine();
 
     t = opt_result.base_to_camera[0].inverse() * t;
-    rct_ros_tools::printTransform(t, "Camera 0", " Camera " + std::to_string(c), "CAMERA 0 TO CAMERA (" + param_base + ")");
-    rct_ros_tools::printNewLine();
+    printTransform(t, "Camera 0", " Camera " + std::to_string(c), "CAMERA 0 TO CAMERA (" + param_base + ")");
+    printNewLine();
   }
 
-  rct_ros_tools::printTitle("REPROJECTION ERROR");
+  printTitle("REPROJECTION ERROR");
 
   for (std::size_t i = 0; i < maybe_data_set[0].images.size(); ++i)
   {
-    std::vector<rct_optimizations::Correspondence2D3D::Set> corr_set;
+    std::vector<Correspondence2D3D::Set> corr_set;
     std::vector<Eigen::Isometry3d> base_to_camera;
     Eigen::Isometry3d base_to_wrist;
-    std::vector<rct_optimizations::CameraIntrinsics> intr;
+    std::vector<CameraIntrinsics> intr;
     cv::Mat image;
 
     corr_set.reserve(num_of_cameras);
@@ -230,7 +235,7 @@ int main(int argc, char** argv)
 
     if (cnt >= 2)
     {
-      rct_ros_tools::printTitle("REPROJECT IMAGE " + std::to_string(i));
+      printTitle("REPROJECT IMAGE " + std::to_string(i));
       reproject(base_to_wrist * opt_result.wrist_to_target, base_to_camera,
                 intr, target, image, corr_set);
     }

--- a/rct_examples/src/tools/multi_static_camera_multi_step_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_multi_step_extrinsic.cpp
@@ -1,6 +1,7 @@
 // Utilities for loading data sets and calib parameters from YAML files via ROS
 #include "rct_ros_tools/data_set.h"
 #include "rct_ros_tools/parameter_loaders.h"
+#include "rct_ros_tools/target_loaders.h"
 #include "rct_ros_tools/print_utils.h"
 // To find 2D  observations from images
 #include <rct_image_tools/image_observation_finder.h>
@@ -16,40 +17,44 @@
 #include <rct_optimizations/ceres_math_utilities.h>
 #include <rct_optimizations/experimental/multi_camera_pnp.h>
 
+using namespace rct_optimizations;
+using namespace rct_image_tools;
+using namespace rct_ros_tools;
+
 static void reproject(const Eigen::Isometry3d& base_to_target,
                       const std::vector<Eigen::Isometry3d>& base_to_camera,
-                      const std::vector<rct_optimizations::CameraIntrinsics>& intr,
-                      const rct_image_tools::ModifiedCircleGridTarget& target,
+                      const std::vector<CameraIntrinsics>& intr,
+                      const ModifiedCircleGridTarget& target,
                       const cv::Mat& image,
-                      const std::vector<rct_optimizations::Correspondence2D3D::Set>& corr)
+                      const std::vector<Correspondence2D3D::Set>& corr)
 {
 
   Eigen::Isometry3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections = rct_image_tools::getReprojections(camera_to_target, intr[0], target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr[0], target.points);
 
   cv::Mat before_frame = image.clone();
-  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
+  drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
 
-  rct_optimizations::MultiCameraPnPProblem pb;
+  MultiCameraPnPProblem pb;
   pb.base_to_camera = base_to_camera;
   pb.base_to_target_guess = base_to_target;
   pb.image_observations = corr;
   pb.intr = intr;
 
-  rct_optimizations::MultiCameraPnPResult r = rct_optimizations::optimize(pb);
-  rct_ros_tools::printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  MultiCameraPnPResult r = optimize(pb);
+  printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
+  printNewLine();
 
-  rct_ros_tools::printTransform(camera_to_target, "Camera 0", "Target", "CAMERA 0 TO TARGET");
-  rct_ros_tools::printNewLine();
+  printTransform(camera_to_target, "Camera 0", "Target", "CAMERA 0 TO TARGET");
+  printNewLine();
 
   Eigen::Isometry3d result_camera_to_target = base_to_camera[0].inverse() * r.base_to_target;
-  rct_ros_tools::printTransformDiff(camera_to_target, result_camera_to_target, "Camera 0", "Target", "PNP");
-  rct_ros_tools::printNewLine();
+  printTransformDiff(camera_to_target, result_camera_to_target, "Camera 0", "Target", "PNP");
+  printNewLine();
 
-  reprojections = rct_image_tools::getReprojections(result_camera_to_target, intr[0], target.points);
+  reprojections = getReprojections(result_camera_to_target, intr[0], target.points);
   cv::Mat after_frame = image.clone();
-  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
+  drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
 
   cv::imshow("repr_before", before_frame);
   cv::imshow("repr_after", after_frame);
@@ -69,11 +74,11 @@ int main(int argc, char** argv)
   }
   std::size_t num_of_cameras = camera_count;
 
-  rct_optimizations::ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem problem_wrist_def;
-  rct_optimizations::ExtrinsicMultiStaticCameraOnlyProblem problem_def;
+  ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem problem_wrist_def;
+  ExtrinsicMultiStaticCameraOnlyProblem problem_def;
   std::vector<std::string> data_path;
   std::string target_path;
-  std::vector<rct_ros_tools::ExtrinsicDataSet> maybe_data_set;
+  std::vector<ExtrinsicDataSet> maybe_data_set;
   bool fix_first_camera;
 
   data_path.resize(num_of_cameras);
@@ -93,7 +98,7 @@ int main(int argc, char** argv)
     }
 
     // Attempt to load the data set from the specified path
-    boost::optional<rct_ros_tools::ExtrinsicDataSet> data_set = rct_ros_tools::parseFromFile(data_path[c]);
+    boost::optional<ExtrinsicDataSet> data_set = parseFromFile(data_path[c]);
     if (!data_set)
     {
       ROS_ERROR_STREAM("Failed to parse data set from path = " << data_path[c]);
@@ -108,14 +113,14 @@ int main(int argc, char** argv)
     problem_def.intr[c].fy() = 1408.0;
     problem_def.intr[c].cx() = 807.2;
     problem_def.intr[c].cy() = 615.0;
-    if (!rct_ros_tools::loadIntrinsics(pnh, param_name, problem_def.intr[c]))
+    if (!loadIntrinsics(pnh, param_name, problem_def.intr[c]))
     {
       ROS_WARN("Unable to load camera intrinsics from the '%s' parameter struct", param_name.c_str());
     }
 
     param_name = param_base + "base_to_camera_guess";
     // Our 'base to camera guess': A camera off to the side, looking at a point centered in front of the robot
-    if (!rct_ros_tools::loadPose(pnh, param_name, problem_def.base_to_camera_guess[c]))
+    if (!loadPose(pnh, param_name, problem_def.base_to_camera_guess[c]))
     {
       ROS_WARN("Unable to load guess for base to camera from the '%s' parameter struct", param_name.c_str());
     }
@@ -135,23 +140,23 @@ int main(int argc, char** argv)
 
   // Load target definition from parameter server. Target will get
   // reset if such a parameter was set.
-  rct_image_tools::ModifiedCircleGridTarget target(5, 5, 0.015);
-  if (!rct_ros_tools::loadTarget(target_path, target))
+  ModifiedCircleGridTarget target(5, 5, 0.015);
+  if (!TargetLoader<ModifiedCircleGridTarget>::load(target_path, target))
   {
     ROS_WARN_STREAM("Unable to load target file from the 'target_path' parameter");
   }
 
   Eigen::Isometry3d wrist_to_target;
-  if (!rct_ros_tools::loadPose(pnh, "wrist_to_target_guess", wrist_to_target))
+  if (!loadPose(pnh, "wrist_to_target_guess", wrist_to_target))
   {
     ROS_WARN_STREAM("Unable to load guess for wrist to target from the 'wrist_to_target_guess' parameter struct");
     return 1;
   }
 
   // Lets create a class that will search for the target in our raw images.
-  rct_image_tools::ModifiedCircleGridObservationFinder obs_finder(target);
+  ModifiedCircleGridObservationFinder obs_finder(target);
 
-  rct_ros_tools::ExtrinsicCorrespondenceDataSet corr_data_set(maybe_data_set, obs_finder, true);
+  ExtrinsicCorrespondenceDataSet corr_data_set(maybe_data_set, obs_finder, true);
 
   // build problem
   problem_def.fix_first_camera = fix_first_camera;
@@ -171,14 +176,14 @@ int main(int argc, char** argv)
   }
 
   // Run optimization
-  rct_ros_tools::printTitle("Running calibration for only cameras");
+  printTitle("Running calibration for only cameras");
 
-  rct_optimizations::ExtrinsicMultiStaticCameraOnlyResult
-      opt_result = rct_optimizations::optimize(problem_def);
+  ExtrinsicMultiStaticCameraOnlyResult
+      opt_result = optimize(problem_def);
 
   // Report results
-  rct_ros_tools::printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
+  printNewLine();
 
   for (std::size_t c = 0; c < num_of_cameras; ++c)
   {
@@ -186,31 +191,31 @@ int main(int argc, char** argv)
     std::string param_base = "camera_" + std::to_string(c);
 
     Eigen::Isometry3d t = opt_result.base_to_camera[c];
-    rct_ros_tools::printTransform(t, "Base", "Camera (" + param_base + ")", "Base To Camera (" + param_base + ")");
-    rct_ros_tools::printNewLine();
+    printTransform(t, "Base", "Camera (" + param_base + ")", "Base To Camera (" + param_base + ")");
+    printNewLine();
 
     t = opt_result.base_to_camera[0].inverse()  * t;
-    rct_ros_tools::printTransform(t, "Camera 0", "Camera (" + param_base + ")", "Camera 0 to Camera " + std::to_string(c));
-    rct_ros_tools::printNewLine();
+    printTransform(t, "Camera 0", "Camera (" + param_base + ")", "Camera 0 to Camera " + std::to_string(c));
+    printNewLine();
   }
 
   // Run optimization
-  rct_ros_tools::printTitle("Running calibration for wrist only using camera only results");
+  printTitle("Running calibration for wrist only using camera only results");
 
   problem_wrist_def.intr = problem_def.intr;
   problem_wrist_def.wrist_to_target_guess = wrist_to_target;
   problem_wrist_def.image_observations = problem_def.image_observations;
   problem_wrist_def.base_to_camera_guess = opt_result.base_to_camera;
-  rct_optimizations::ExtrinsicMultiStaticCameraMovingTargetWristOnlyResult
-      opt_wrist_only_result = rct_optimizations::optimize(problem_wrist_def);
+  ExtrinsicMultiStaticCameraMovingTargetWristOnlyResult
+      opt_wrist_only_result = optimize(problem_wrist_def);
 
   // Report results
-  rct_ros_tools::printOptResults(opt_wrist_only_result.converged, opt_wrist_only_result.initial_cost_per_obs, opt_wrist_only_result.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(opt_wrist_only_result.converged, opt_wrist_only_result.initial_cost_per_obs, opt_wrist_only_result.final_cost_per_obs);
+  printNewLine();
 
   Eigen::Isometry3d t = opt_wrist_only_result.wrist_to_target;
-  rct_ros_tools::printTransform(t, "Wrist", "Target", "Wrist to Target");
-  rct_ros_tools::printNewLine();
+  printTransform(t, "Wrist", "Target", "Wrist to Target");
+  printNewLine();
 
   for (std::size_t c = 0; c < num_of_cameras; ++c)
   {
@@ -218,22 +223,22 @@ int main(int argc, char** argv)
     std::string param_base = "camera_" + std::to_string(c);
 
     t = opt_wrist_only_result.base_to_camera[c];
-    rct_ros_tools::printTransform(t, "Base", "Camera (" + param_base + ")", "Base To Camera (" + param_base + ")");
-    rct_ros_tools::printNewLine();
+    printTransform(t, "Base", "Camera (" + param_base + ")", "Base To Camera (" + param_base + ")");
+    printNewLine();
 
     t = opt_wrist_only_result.base_to_camera[0].inverse() * t;
-    rct_ros_tools::printTransform(t, "Camera 0", "Camera (" + param_base + ")", "Camera 0 to Camera " + std::to_string(c));
-    rct_ros_tools::printNewLine();
+    printTransform(t, "Camera 0", "Camera (" + param_base + ")", "Camera 0 to Camera " + std::to_string(c));
+    printNewLine();
   }
 
-  rct_ros_tools::printTitle("REPROJECTION ERROR");
+  printTitle("REPROJECTION ERROR");
 
   for (std::size_t i = 0; i < problem_wrist_def.wrist_poses.size(); ++i)
   {
-    std::vector<rct_optimizations::Correspondence2D3D::Set> corr_set;
+    std::vector<Correspondence2D3D::Set> corr_set;
     std::vector<Eigen::Isometry3d> base_to_camera;
     Eigen::Isometry3d base_to_target;
-    std::vector<rct_optimizations::CameraIntrinsics> intr;
+    std::vector<CameraIntrinsics> intr;
 
     corr_set.reserve(num_of_cameras);
     base_to_camera.reserve(num_of_cameras);
@@ -248,7 +253,7 @@ int main(int argc, char** argv)
       corr_set.push_back(problem_def.image_observations[c][i]);
     }
 
-    rct_ros_tools::printTitle("REPROJECT IMAGE " + std::to_string(i));
+    printTitle("REPROJECT IMAGE " + std::to_string(i));
     reproject(base_to_target, base_to_camera,
               intr, target, maybe_data_set[0].images[i], corr_set);
   }

--- a/rct_examples/src/tools/multi_static_camera_multi_step_extrinsic.cpp
+++ b/rct_examples/src/tools/multi_static_camera_multi_step_extrinsic.cpp
@@ -30,7 +30,7 @@ static void reproject(const Eigen::Isometry3d& base_to_target,
 {
 
   Eigen::Isometry3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr[0], target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr[0], target.createPoints());
 
   cv::Mat before_frame = image.clone();
   drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
@@ -52,7 +52,7 @@ static void reproject(const Eigen::Isometry3d& base_to_target,
   printTransformDiff(camera_to_target, result_camera_to_target, "Camera 0", "Target", "PNP");
   printNewLine();
 
-  reprojections = getReprojections(result_camera_to_target, intr[0], target.points);
+  reprojections = getReprojections(result_camera_to_target, intr[0], target.createPoints());
   cv::Mat after_frame = image.clone();
   drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
 

--- a/rct_examples/src/tools/noise_qualification_2d.cpp
+++ b/rct_examples/src/tools/noise_qualification_2d.cpp
@@ -85,9 +85,10 @@ int main(int argc, char** argv)
 
       // Add the detected correspondences
       problem.correspondences.reserve(maybe_obs->size());
+      const std::vector<Eigen::Vector3d> target_points = target.createPoints();
       for (std::size_t j = 0; j < maybe_obs->size(); ++j)
       {
-        problem.correspondences.emplace_back(maybe_obs->at(j), target.points.at(j));
+        problem.correspondences.emplace_back(maybe_obs->at(j), target_points.at(j));
       };
 
       problem_set.push_back(problem);

--- a/rct_examples/src/tools/noise_qualification_2d.cpp
+++ b/rct_examples/src/tools/noise_qualification_2d.cpp
@@ -3,8 +3,13 @@
 #include <rct_optimizations/validation/noise_qualification.h>
 #include "rct_ros_tools/data_set.h"
 #include "rct_ros_tools/parameter_loaders.h"
+#include "rct_ros_tools/target_loaders.h"
 #include <ros/ros.h>
 #include <yaml-cpp/yaml.h>
+
+using namespace rct_optimizations;
+using namespace rct_image_tools;
+using namespace rct_ros_tools;
 
 template<typename T>
 bool get(const ros::NodeHandle &nh, const std::string &key, T &val)
@@ -34,27 +39,27 @@ int main(int argc, char** argv)
   try
   {
     // Load the target definition and observation finder
-    rct_image_tools::ModifiedCircleGridTarget target = rct_ros_tools::loadTarget(pnh, "target_definition");
-    rct_image_tools::ModifiedCircleGridObservationFinder obs_finder(target);
+    auto target = TargetLoader<ModifiedCircleGridTarget>::load(pnh, "target_definition");
+    ModifiedCircleGridObservationFinder obs_finder(target);
 
     // Load camera intrinsics
-    rct_optimizations::CameraIntrinsics camera = rct_ros_tools::loadIntrinsics(pnh, "intrinsics");
+    CameraIntrinsics camera = loadIntrinsics(pnh, "intrinsics");
 
     // Load an initial guess for the camera to target transformation
-    Eigen::Isometry3d camera_to_target_guess = rct_ros_tools::loadPose(pnh, "camera_to_target_guess");
+    Eigen::Isometry3d camera_to_target_guess = loadPose(pnh, "camera_to_target_guess");
 
     // Load the data file which specifies the location of the images on which to perform the noise qualification
     YAML::Node root = YAML::LoadFile(data_file);
 
     // Set up the noise qualification inputs
-    std::vector<rct_optimizations::PnPProblem> problem_set;
+    std::vector<PnPProblem> problem_set;
     problem_set.reserve(root.size());
     for (std::size_t i = 0; i < root.size(); ++i)
     {
       // Each entry should have an image path. This path is relative to the root_path directory!
       const auto img_path = root[i]["image"].as<std::string>();
       const std::string image_name = data_path + "/" + img_path;
-      static cv::Mat image = rct_ros_tools::readImageOpenCV(image_name);
+      static cv::Mat image = readImageOpenCV(image_name);
 
       // Find the observations in the image
       auto maybe_obs = obs_finder.findObservations(image);
@@ -74,7 +79,7 @@ int main(int argc, char** argv)
       }
 
       // Set up the PnP problem for this image
-      rct_optimizations::PnPProblem problem;
+      PnPProblem problem;
       problem.intr = camera;
       problem.camera_to_target_guess = camera_to_target_guess;
 
@@ -89,7 +94,7 @@ int main(int argc, char** argv)
     }
 
     // Perform the noise qualification
-    rct_optimizations::PnPNoiseStat result = rct_optimizations::qualifyNoise2D(problem_set);
+    PnPNoiseStat result = qualifyNoise2D(problem_set);
 
     // Print the results
     Eigen::IOFormat fmt(4, 0, ",", "\n", "[", "]");

--- a/rct_examples/src/tools/solve_multi_camera_pnp.cpp
+++ b/rct_examples/src/tools/solve_multi_camera_pnp.cpp
@@ -31,7 +31,7 @@ static void reproject(const Eigen::Isometry3d& base_to_target,
 {
 
   Eigen::Isometry3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr[0], target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr[0], target.createPoints());
 
   cv::Mat before_frame = image.clone();
   drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
@@ -59,7 +59,7 @@ static void reproject(const Eigen::Isometry3d& base_to_target,
   printNewLine();
 
   Eigen::Isometry3d result_camera_to_target = base_to_camera[0].inverse() * r.base_to_target;
-  reprojections = getReprojections(result_camera_to_target, intr[0], target.points);
+  reprojections = getReprojections(result_camera_to_target, intr[0], target.createPoints());
 
   cv::Mat after_frame = image.clone();
   drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);

--- a/rct_examples/src/tools/solve_multi_camera_pnp.cpp
+++ b/rct_examples/src/tools/solve_multi_camera_pnp.cpp
@@ -14,50 +14,55 @@
 #include <rct_optimizations/experimental/multi_camera_pnp.h>
 #include <rct_optimizations/ceres_math_utilities.h>
 #include <rct_ros_tools/parameter_loaders.h>
+#include <rct_ros_tools/target_loaders.h>
 #include <rct_ros_tools/data_set.h>
 #include <rct_ros_tools/print_utils.h>
 
+using namespace rct_optimizations;
+using namespace rct_image_tools;
+using namespace rct_ros_tools;
+
 static void reproject(const Eigen::Isometry3d& base_to_target,
                       const std::vector<Eigen::Isometry3d>& base_to_camera,
-                      const std::vector<rct_optimizations::CameraIntrinsics>& intr,
-                      const rct_image_tools::ModifiedCircleGridTarget& target,
+                      const std::vector<CameraIntrinsics>& intr,
+                      const ModifiedCircleGridTarget& target,
                       const cv::Mat& image,
-                      const std::vector<rct_optimizations::Correspondence2D3D::Set>& corr)
+                      const std::vector<Correspondence2D3D::Set>& corr)
 {
 
   Eigen::Isometry3d camera_to_target = base_to_camera[0].inverse() * base_to_target;
-  std::vector<cv::Point2d> reprojections = rct_image_tools::getReprojections(camera_to_target, intr[0], target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr[0], target.points);
 
   cv::Mat before_frame = image.clone();
-  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
+  drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), before_frame);
 
-  rct_optimizations::MultiCameraPnPProblem pb;
+  MultiCameraPnPProblem pb;
   pb.base_to_camera = base_to_camera;
   pb.base_to_target_guess = base_to_target;
   pb.image_observations = corr;
   pb.intr = intr;
 
-  rct_optimizations::MultiCameraPnPResult r = rct_optimizations::optimize(pb);
+  MultiCameraPnPResult r = optimize(pb);
   // Report results
-  rct_ros_tools::printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
+  printNewLine();
 
   // We want to compute the "positional error" as well
   // So first we compute the "camera to target" transform based on the calibration...
-  rct_ros_tools::printTransform(base_to_target, "Base", "Target", "BASE TO TARGET");
-  rct_ros_tools::printNewLine();
+  printTransform(base_to_target, "Base", "Target", "BASE TO TARGET");
+  printNewLine();
 
-  rct_ros_tools::printTransform(r.base_to_target, "Base", "Target", "PNP");
-  rct_ros_tools::printNewLine();
+  printTransform(r.base_to_target, "Base", "Target", "PNP");
+  printNewLine();
 
-  rct_ros_tools::printTransformDiff(base_to_target, r.base_to_target, "Base", "Target", "PNP Diff");
-  rct_ros_tools::printNewLine();
+  printTransformDiff(base_to_target, r.base_to_target, "Base", "Target", "PNP Diff");
+  printNewLine();
 
   Eigen::Isometry3d result_camera_to_target = base_to_camera[0].inverse() * r.base_to_target;
-  reprojections = rct_image_tools::getReprojections(result_camera_to_target, intr[0], target.points);
+  reprojections = getReprojections(result_camera_to_target, intr[0], target.points);
 
   cv::Mat after_frame = image.clone();
-  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
+  drawReprojections(reprojections, 3, cv::Scalar(0, 255, 0), after_frame);
 
   cv::imshow("repr_before", before_frame);
   cv::imshow("repr_after", after_frame);
@@ -78,10 +83,10 @@ int main(int argc, char** argv)
   std::size_t num_of_cameras = camera_count;
 
   std::vector<Eigen::Isometry3d> base_to_camera;
-  std::vector<rct_optimizations::CameraIntrinsics> intr;
+  std::vector<CameraIntrinsics> intr;
   std::vector<std::string> data_path;
   std::string target_path;
-  std::vector<rct_ros_tools::ExtrinsicDataSet> maybe_data_set;
+  std::vector<ExtrinsicDataSet> maybe_data_set;
 
   data_path.resize(num_of_cameras);
   maybe_data_set.resize(num_of_cameras);
@@ -99,7 +104,7 @@ int main(int argc, char** argv)
     }
 
     // Attempt to load the data set from the specified path
-    boost::optional<rct_ros_tools::ExtrinsicDataSet> data_set = rct_ros_tools::parseFromFile(data_path[c]);
+    boost::optional<ExtrinsicDataSet> data_set = parseFromFile(data_path[c]);
     if (!data_set)
     {
       ROS_ERROR_STREAM("Failed to parse data set from path = " << data_path[c]);
@@ -114,14 +119,14 @@ int main(int argc, char** argv)
     intr[c].fy() = 1408.0;
     intr[c].cx() = 807.2;
     intr[c].cy() = 615.0;
-    if (!rct_ros_tools::loadIntrinsics(pnh, param_name, intr[c]))
+    if (!loadIntrinsics(pnh, param_name, intr[c]))
     {
       ROS_WARN("Unable to load camera intrinsics from the '%s' parameter struct", param_name.c_str());
     }
 
     param_name = param_base + "base_to_camera";
     // Our 'base to camera guess': A camera off to the side, looking at a point centered in front of the robot
-    if (!rct_ros_tools::loadPose(pnh, param_name, base_to_camera[c]))
+    if (!loadPose(pnh, param_name, base_to_camera[c]))
     {
       ROS_WARN("Unable to load guess for base to camera from the '%s' parameter struct", param_name.c_str());
     }
@@ -135,28 +140,28 @@ int main(int argc, char** argv)
 
   // Load target definition from parameter server. Target will get
   // reset if such a parameter was set.
-  rct_image_tools::ModifiedCircleGridTarget target(5, 5, 0.015);
-  if (!rct_ros_tools::loadTarget(target_path, target))
+  ModifiedCircleGridTarget target(5, 5, 0.015);
+  if (!TargetLoader<ModifiedCircleGridTarget>::load(target_path, target))
   {
     ROS_WARN_STREAM("Unable to load target file from the 'target_path' parameter");
   }
 
   // Lets create a class that will search for the target in our raw images.
-  rct_image_tools::ModifiedCircleGridObservationFinder obs_finder(target);
+  ModifiedCircleGridObservationFinder obs_finder(target);
 
-  rct_ros_tools::ExtrinsicCorrespondenceDataSet corr_data_set(maybe_data_set, obs_finder, true);
+  ExtrinsicCorrespondenceDataSet corr_data_set(maybe_data_set, obs_finder, true);
 
   for (std::size_t i = 0; i < corr_data_set.getImageCount(); ++i)
   {
     if (corr_data_set.getImageCameraCount(i) == corr_data_set.getCameraCount())
     {
-      std::vector<rct_optimizations::Correspondence2D3D::Set> corr_set;
+      std::vector<Correspondence2D3D::Set> corr_set;
       for (std::size_t c = 0; c < num_of_cameras; ++c)
       {
         corr_set.push_back(corr_data_set.getCorrespondenceSet(c, i));
       }
 
-      rct_ros_tools::printTitle("REPROJECT IMAGE " + std::to_string(i));
+      printTitle("REPROJECT IMAGE " + std::to_string(i));
       reproject(maybe_data_set[0].tool_poses[i], base_to_camera,
                 intr, target, maybe_data_set[0].images[i], corr_set);
     }

--- a/rct_examples/src/tools/solve_pnp.cpp
+++ b/rct_examples/src/tools/solve_pnp.cpp
@@ -39,7 +39,7 @@ static Eigen::Isometry3d solveCVPnP(const CameraIntrinsics& intr,
     image_points.push_back(cv::Point2d(o(0), o(1)));
 
   std::vector<cv::Point3d> target_points;
-  for (const auto p : target.points)
+  for (const auto p : target.createPoints())
     target_points.push_back( cv::Point3d(p(0), p(1), p(2)) );
 
   cv::Mat rvec (3, 1, cv::DataType<double>::type);
@@ -109,7 +109,7 @@ int main(int argc, char** argv)
   PnPProblem params;
   params.intr = intr;
   params.camera_to_target_guess = guess;
-  params.correspondences = getCorrespondenceSet(*maybe_obs, target.points);
+  params.correspondences = getCorrespondenceSet(*maybe_obs, target.createPoints());
 
   PnPResult pnp_result = optimize(params);
 

--- a/rct_examples/src/tools/solve_pnp.cpp
+++ b/rct_examples/src/tools/solve_pnp.cpp
@@ -12,10 +12,15 @@
 #include <rct_image_tools/image_utils.h>
 #include <rct_optimizations/pnp.h>
 #include <rct_ros_tools/parameter_loaders.h>
+#include <rct_ros_tools/target_loaders.h>
 #include <rct_ros_tools/print_utils.h>
 
-static Eigen::Isometry3d solveCVPnP(const rct_optimizations::CameraIntrinsics& intr,
-                                  const rct_image_tools::ModifiedCircleGridTarget& target,
+using namespace rct_optimizations;
+using namespace rct_image_tools;
+using namespace rct_ros_tools;
+
+static Eigen::Isometry3d solveCVPnP(const CameraIntrinsics& intr,
+                                  const ModifiedCircleGridTarget& target,
                                   const std::vector<Eigen::Vector2d>& obs)
 {
   cv::Mat cam_matrix (3, 3, cv::DataType<double>::type);
@@ -26,8 +31,8 @@ static Eigen::Isometry3d solveCVPnP(const rct_optimizations::CameraIntrinsics& i
   cam_matrix.at<double>(0, 2) = intr.cx();
   cam_matrix.at<double>(1, 2) = intr.cy();
 
-  rct_ros_tools::printCameraIntrinsics(intr.values, "Camera Intrinsics");
-  rct_ros_tools::printNewLine();
+  printCameraIntrinsics(intr.values, "Camera Intrinsics");
+  printNewLine();
 
   std::vector<cv::Point2d> image_points;
   for (const auto o : obs)
@@ -45,8 +50,8 @@ static Eigen::Isometry3d solveCVPnP(const rct_optimizations::CameraIntrinsics& i
   Eigen::Isometry3d result(Eigen::AngleAxisd(rr.norm(), rr.normalized()));
   result.translation() = Eigen::Vector3d(tvec.at<double>(0, 0), tvec.at<double>(1, 0), tvec.at<double>(2, 0));
 
-  rct_ros_tools::printTransform(result, "Camera", "Target", "OpenCV solvePNP");
-  rct_ros_tools::printNewLine();
+  printTransform(result, "Camera", "Target", "OpenCV solvePNP");
+  printNewLine();
 
   return result;
 }
@@ -68,22 +73,22 @@ int main(int argc, char** argv)
   cv::Mat mat = cv::imread(image_path);
 
   // Load target definition from parameter server
-  rct_image_tools::ModifiedCircleGridTarget target;
-  if (!rct_ros_tools::loadTarget(pnh, "target_definition", target))
+  ModifiedCircleGridTarget target;
+  if (!TargetLoader<ModifiedCircleGridTarget>::load(pnh, "target_definition", target))
   {
     ROS_WARN_STREAM("Unable to load target from the 'target_definition' parameter struct");
     return 1;
   }
 
   // Load the camera intrinsics from the parameter server
-  rct_optimizations::CameraIntrinsics intr;
-  if (!rct_ros_tools::loadIntrinsics(pnh, "intrinsics", intr))
+  CameraIntrinsics intr;
+  if (!loadIntrinsics(pnh, "intrinsics", intr))
   {
     ROS_WARN_STREAM("Unable to load camera intrinsics from the 'intrinsics' parameter struct");
     return 1;
   }
 
-  rct_image_tools::ModifiedCircleGridObservationFinder finder (target);
+  ModifiedCircleGridObservationFinder finder (target);
   auto maybe_obs = finder.findObservations(mat);
   if (!maybe_obs)
   {
@@ -101,18 +106,18 @@ int main(int argc, char** argv)
   Eigen::Isometry3d guess = Eigen::Isometry3d::Identity();
   guess = guess * Eigen::Translation3d(0,0,0.1) * Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX());
 
-  rct_optimizations::PnPProblem params;
+  PnPProblem params;
   params.intr = intr;
   params.camera_to_target_guess = guess;
-  params.correspondences = rct_image_tools::getCorrespondenceSet(*maybe_obs, target.points);
+  params.correspondences = getCorrespondenceSet(*maybe_obs, target.points);
 
-  rct_optimizations::PnPResult pnp_result = rct_optimizations::optimize(params);
+  PnPResult pnp_result = optimize(params);
 
-  rct_ros_tools::printOptResults(pnp_result.converged, pnp_result.initial_cost_per_obs, pnp_result.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(pnp_result.converged, pnp_result.initial_cost_per_obs, pnp_result.final_cost_per_obs);
+  printNewLine();
 
-  rct_ros_tools::printTransform(pnp_result.camera_to_target, "Camera", "Target", "RCT CAMERA TO TARGET");
-  rct_ros_tools::printNewLine();
+  printTransform(pnp_result.camera_to_target, "Camera", "Target", "RCT CAMERA TO TARGET");
+  printNewLine();
 
   return 0;
 }

--- a/rct_examples/src/tools/static_camera_extrinsic.cpp
+++ b/rct_examples/src/tools/static_camera_extrinsic.cpp
@@ -1,6 +1,7 @@
 // Utilities for loading data sets and calib parameters from YAML files via ROS
 #include "rct_ros_tools/data_set.h"
 #include "rct_ros_tools/parameter_loaders.h"
+#include "rct_ros_tools/target_loaders.h"
 #include "rct_ros_tools/print_utils.h"
 // To find 2D  observations from images
 #include <rct_image_tools/image_observation_finder.h>
@@ -15,29 +16,33 @@
 #include <rct_optimizations/ceres_math_utilities.h>
 #include <rct_optimizations/pnp.h>
 
+using namespace rct_optimizations;
+using namespace rct_image_tools;
+using namespace rct_ros_tools;
+
 static void reproject(const Eigen::Isometry3d& wrist_to_target, const Eigen::Isometry3d& base_to_camera,
-                      const rct_optimizations::Observation2D3D& obs, const rct_optimizations::CameraIntrinsics& intr,
-                      const rct_image_tools::ModifiedCircleGridTarget& target, const cv::Mat& image)
+                      const Observation2D3D& obs, const CameraIntrinsics& intr,
+                      const ModifiedCircleGridTarget& target, const cv::Mat& image)
 {
   Eigen::Isometry3d camera_to_target = base_to_camera.inverse() * (obs.to_target_mount * wrist_to_target);
-  std::vector<cv::Point2d> reprojections = rct_image_tools::getReprojections(camera_to_target, intr, target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr, target.points);
 
   cv::Mat frame = image.clone();
-  rct_image_tools::drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), frame);
+  drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), frame);
 
   // We want to compute the "positional error" as well
   // So first we compute the "camera to target" transform based on the calibration...
-  rct_optimizations::PnPProblem pb;
+  PnPProblem pb;
   pb.camera_to_target_guess = camera_to_target;
   pb.correspondences = obs.correspondence_set;
   pb.intr = intr;
-  rct_optimizations::PnPResult r = rct_optimizations::optimize(pb);
+  PnPResult r = optimize(pb);
 
-  rct_ros_tools::printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(r.converged, r.initial_cost_per_obs, r.final_cost_per_obs);
+  printNewLine();
 
-  rct_ros_tools::printTransformDiff(camera_to_target, r.camera_to_target, "Camera", "Target", "PNP Diff");
-  rct_ros_tools::printNewLine();
+  printTransformDiff(camera_to_target, r.camera_to_target, "Camera", "Target", "PNP Diff");
+  printNewLine();
 
   cv::imshow("repr", frame);
   cv::waitKey();
@@ -57,45 +62,45 @@ int main(int argc, char** argv)
   }
 
   // Attempt to load the data set from the specified path
-  boost::optional<rct_ros_tools::ExtrinsicDataSet> maybe_data_set = rct_ros_tools::parseFromFile(data_path);
+  boost::optional<ExtrinsicDataSet> maybe_data_set = parseFromFile(data_path);
   if (!maybe_data_set)
   {
     ROS_ERROR_STREAM("Failed to parse data set from path = " << data_path);
     return 2;
   }
   // We know it exists, so define a helpful alias
-  const rct_ros_tools::ExtrinsicDataSet& data_set = *maybe_data_set;
+  const ExtrinsicDataSet& data_set = *maybe_data_set;
 
-  rct_image_tools::ModifiedCircleGridTarget target(5, 5, 0.015);
-  if (!rct_ros_tools::loadTarget(pnh, "target_definition", target))
+  ModifiedCircleGridTarget target(5, 5, 0.015);
+  if (!TargetLoader<ModifiedCircleGridTarget>::load(pnh, "target_definition", target))
   {
     ROS_WARN_STREAM("Unable to load target from the 'target_definition' parameter struct");
     return 1;
   }
 
-  rct_optimizations::CameraIntrinsics intr;
-  if (!rct_ros_tools::loadIntrinsics(pnh, "intrinsics", intr))
+  CameraIntrinsics intr;
+  if (!loadIntrinsics(pnh, "intrinsics", intr))
   {
     ROS_WARN_STREAM("Unable to load camera intrinsics from the 'intrinsics' parameter struct");
     return 1;
   }
 
   // Lets create a class that will search for the target in our raw images.
-  rct_image_tools::ModifiedCircleGridObservationFinder obs_finder(target);
+  ModifiedCircleGridObservationFinder obs_finder(target);
 
   // Now we construct our problem:
-  rct_optimizations::ExtrinsicHandEyeProblem2D3D problem_def;
+  ExtrinsicHandEyeProblem2D3D problem_def;
   // Our camera intrinsics to use
   problem_def.intr = intr;
 
   // Our 'base to camera guess': A camera off to the side, looking at a point centered in front of the robot
-  if (!rct_ros_tools::loadPose(pnh, "base_to_camera_guess", problem_def.camera_mount_to_camera_guess))
+  if (!loadPose(pnh, "base_to_camera_guess", problem_def.camera_mount_to_camera_guess))
   {
     ROS_WARN_STREAM("Unable to load guess for base to camera from the 'base_to_camera_guess' parameter struct");
     return 1;
   }
 
-  if (!rct_ros_tools::loadPose(pnh, "wrist_to_target_guess", problem_def.target_mount_to_target_guess))
+  if (!loadPose(pnh, "wrist_to_target_guess", problem_def.target_mount_to_target_guess))
   {
     ROS_WARN_STREAM("Unable to load guess for wrist to target from the 'wrist_to_target_guess' parameter struct");
     return 1;
@@ -104,7 +109,7 @@ int main(int argc, char** argv)
   // Finally, we need to process our images into correspondence sets: for each dot in the
   // target this will be where that dot is in the target and where it was seen in the image.
   // Repeat for each image. We also tell where the wrist was when the image was taken.
-  rct_ros_tools::ExtrinsicDataSet found_images;
+  ExtrinsicDataSet found_images;
   problem_def.observations.reserve(data_set.images.size());
   for (std::size_t i = 0; i < data_set.images.size(); ++i)
   {
@@ -128,7 +133,7 @@ int main(int argc, char** argv)
     found_images.images.push_back(data_set.images[i]);
     found_images.tool_poses.push_back(data_set.tool_poses[i]);
 
-    rct_optimizations::Observation2D3D obs;
+    Observation2D3D obs;
 
     // So for each image we need to:
     //// 1. Record the wrist position
@@ -136,29 +141,29 @@ int main(int argc, char** argv)
     obs.to_camera_mount = Eigen::Isometry3d::Identity();
 
     //// And finally add that to the problem
-    obs.correspondence_set = rct_image_tools::getCorrespondenceSet(*maybe_obs, target.points);
+    obs.correspondence_set = getCorrespondenceSet(*maybe_obs, target.points);
 
     problem_def.observations.push_back(obs);
   }
 
   // Run optimization
-  rct_optimizations::ExtrinsicHandEyeResult opt_result = rct_optimizations::optimize(problem_def);
+  ExtrinsicHandEyeResult opt_result = optimize(problem_def);
 
   // Report results
-  rct_ros_tools::printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
-  rct_ros_tools::printNewLine();
+  printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
+  printNewLine();
 
   Eigen::Isometry3d c = opt_result.camera_mount_to_camera;
-  rct_ros_tools::printTransform(c, "Base", "Camera", "BASE TO CAMERA");
-  rct_ros_tools::printNewLine();
+  printTransform(c, "Base", "Camera", "BASE TO CAMERA");
+  printNewLine();
 
   Eigen::Isometry3d t = opt_result.target_mount_to_target;
-  rct_ros_tools::printTransform(t, "Wrist", "Target", "WRIST_TO_TARGET");
-  rct_ros_tools::printNewLine();
+  printTransform(t, "Wrist", "Target", "WRIST_TO_TARGET");
+  printNewLine();
 
   for (std::size_t i = 0; i < found_images.images.size(); ++i)
   {
-    rct_ros_tools::printTitle("REPROJECT IMAGE " + std::to_string(i));
+    printTitle("REPROJECT IMAGE " + std::to_string(i));
     reproject(opt_result.target_mount_to_target,
               opt_result.camera_mount_to_camera,
               problem_def.observations[i],

--- a/rct_examples/src/tools/static_camera_extrinsic.cpp
+++ b/rct_examples/src/tools/static_camera_extrinsic.cpp
@@ -25,7 +25,7 @@ static void reproject(const Eigen::Isometry3d& wrist_to_target, const Eigen::Iso
                       const ModifiedCircleGridTarget& target, const cv::Mat& image)
 {
   Eigen::Isometry3d camera_to_target = base_to_camera.inverse() * (obs.to_target_mount * wrist_to_target);
-  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr, target.points);
+  std::vector<cv::Point2d> reprojections = getReprojections(camera_to_target, intr, target.createPoints());
 
   cv::Mat frame = image.clone();
   drawReprojections(reprojections, 3, cv::Scalar(0, 0, 255), frame);
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
     obs.to_camera_mount = Eigen::Isometry3d::Identity();
 
     //// And finally add that to the problem
-    obs.correspondence_set = getCorrespondenceSet(*maybe_obs, target.points);
+    obs.correspondence_set = getCorrespondenceSet(*maybe_obs, target.createPoints());
 
     problem_def.observations.push_back(obs);
   }

--- a/rct_image_tools/include/rct_image_tools/image_utils.h
+++ b/rct_image_tools/include/rct_image_tools/image_utils.h
@@ -95,7 +95,7 @@ rct_optimizations::Correspondence2D3D::Set getCorrespondenceSet(const rct_image_
   rct_optimizations::Correspondence2D3D::Set obs_set;
   if (maybe_obs)
   {
-    obs_set = getCorrespondenceSet(*maybe_obs, target.points);
+    obs_set = getCorrespondenceSet(*maybe_obs, target.createPoints());
   }
 
   return obs_set;

--- a/rct_image_tools/include/rct_image_tools/modified_circle_grid_target.h
+++ b/rct_image_tools/include/rct_image_tools/modified_circle_grid_target.h
@@ -6,21 +6,22 @@
 
 namespace rct_image_tools
 {
-
+/**
+ * @brief Structure containing the necessary data to represent a modified circle grid target
+ */
 struct ModifiedCircleGridTarget
 {
   ModifiedCircleGridTarget() = default;
-  ModifiedCircleGridTarget(int rows, int cols, double spacing);
+  ModifiedCircleGridTarget(const unsigned rows, const unsigned cols, const double spacing);
 
-  int rows = 0;
-  int cols = 0;
-  double x_spacing = 0.0;
-  double y_spacing = 0.0;
-  std::vector<Eigen::Vector3d> points;
+  bool operator==(const ModifiedCircleGridTarget& other) const;
 
-private:
-  bool makePoints(std::size_t rows, std::size_t cols, double spacing, std::vector<Eigen::Vector3d>& points);
+  unsigned rows;
+  unsigned cols;
+  double spacing;
+  std::vector<Eigen::Vector3d> createPoints() const;
 };
-}
+
+} // namespace rct_image_tools
 
 #endif // RCT_MODIFIED_CIRCLE_GRID_TARGET_H

--- a/rct_image_tools/src/rct_image_tools/modified_circle_grid_target.cpp
+++ b/rct_image_tools/src/rct_image_tools/modified_circle_grid_target.cpp
@@ -1,14 +1,15 @@
 #include "rct_image_tools/modified_circle_grid_target.h"
 
-rct_image_tools::ModifiedCircleGridTarget::ModifiedCircleGridTarget(int rows, int cols, double spacing)
-    : rows(rows), cols(cols), x_spacing(spacing), y_spacing(spacing)
+namespace rct_image_tools
 {
-  makePoints(rows, cols, spacing, points);
+ModifiedCircleGridTarget::ModifiedCircleGridTarget(const unsigned rows_, const unsigned cols_, const double spacing_)
+  : rows(rows_), cols(cols_), spacing(spacing_)
+{
 }
 
-bool rct_image_tools::ModifiedCircleGridTarget::makePoints(std::size_t rows, std::size_t cols, double spacing,
-                                                           std::vector<Eigen::Vector3d>& points)
+std::vector<Eigen::Vector3d> ModifiedCircleGridTarget::createPoints() const
 {
+  std::vector<Eigen::Vector3d> points;
   points.reserve(rows * cols);
 
   for (std::size_t i = 1; i < (rows + 1); i++)
@@ -22,13 +23,19 @@ bool rct_image_tools::ModifiedCircleGridTarget::makePoints(std::size_t rows, std
     }
   }
 
-  // TODO(gChiou): May need a better check...
-  if (points.size() == (rows * cols))
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  assert(points.size() == (rows * cols));
+
+  return points;
 }
+
+bool ModifiedCircleGridTarget::operator==(const ModifiedCircleGridTarget &other) const
+{
+  bool equal = true;
+  equal &= (rows == other.rows);
+  equal &= (cols == other.cols);
+  equal &= (spacing == other.spacing);
+
+  return equal;
+}
+
+} // namespace rct_image_tools

--- a/rct_ros_tools/CMakeLists.txt
+++ b/rct_ros_tools/CMakeLists.txt
@@ -85,6 +85,7 @@ target_link_libraries(${PROJECT_NAME}_cmd
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
+  find_package(GTest REQUIRED)
   add_rostest_gtest(${PROJECT_NAME}_target_loader_utest test/target_loader.test test/target_loader_utest.cpp)
   target_link_libraries(${PROJECT_NAME}_target_loader_utest
     ${PROJECT_NAME}_data_loader

--- a/rct_ros_tools/CMakeLists.txt
+++ b/rct_ros_tools/CMakeLists.txt
@@ -19,6 +19,8 @@ if(NOT TARGET Eigen3::Eigen)
     set_property(TARGET Eigen3::Eigen PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${EIGEN3_INCLUDE_DIRS})
 endif()
 
+find_package(yaml-cpp REQUIRED)
+
 find_package(catkin REQUIRED COMPONENTS
   roscpp
 
@@ -35,9 +37,12 @@ catkin_package(
     include
   LIBRARIES
     ${PROJECT_NAME}_data_loader
-    yaml-cpp
   CATKIN_DEPENDS
     roscpp
+    tf2_ros
+    cv_bridge
+    image_transport
+    eigen_conversions
 )
 
 ###########

--- a/rct_ros_tools/CMakeLists.txt
+++ b/rct_ros_tools/CMakeLists.txt
@@ -53,7 +53,8 @@ include_directories(
 # development purposes.
 add_library(${PROJECT_NAME}_data_loader
   src/data_loader/data_set.cpp
-  src/data_loader/parameter_loaders.cpp)
+  src/data_loader/parameter_loaders.cpp
+  src/data_loader/modified_circle_grid_target_loader.cpp)
 
 add_dependencies(${PROJECT_NAME}_data_loader ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 

--- a/rct_ros_tools/CMakeLists.txt
+++ b/rct_ros_tools/CMakeLists.txt
@@ -86,7 +86,12 @@ target_link_libraries(${PROJECT_NAME}_cmd
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   add_rostest_gtest(${PROJECT_NAME}_target_loader_utest test/target_loader.test test/target_loader_utest.cpp)
-  target_link_libraries(${PROJECT_NAME}_target_loader_utest ${PROJECT_NAME}_data_loader ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_target_loader_utest
+    ${PROJECT_NAME}_data_loader
+    GTest::GTest
+    GTest::Main
+    ${catkin_LIBRARIES}
+  )
 endif()
 
 #############

--- a/rct_ros_tools/CMakeLists.txt
+++ b/rct_ros_tools/CMakeLists.txt
@@ -55,9 +55,7 @@ add_library(${PROJECT_NAME}_data_loader
   src/data_loader/data_set.cpp
   src/data_loader/parameter_loaders.cpp
   src/data_loader/modified_circle_grid_target_loader.cpp)
-
 add_dependencies(${PROJECT_NAME}_data_loader ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
 target_link_libraries(${PROJECT_NAME}_data_loader
  yaml-cpp
  ${OpenCV_LIBRARIES}
@@ -68,11 +66,8 @@ target_link_libraries(${PROJECT_NAME}_data_loader
 # Executable for collecting data sets via subscribers and triggered with services
 # See readme (TODO: Write a readme)
 add_executable(${PROJECT_NAME}_cmd src/command_line_cal.cpp)
-
 set_target_properties(${PROJECT_NAME}_cmd PROPERTIES OUTPUT_NAME command_line_data_collection PREFIX "")
-
 add_dependencies(${PROJECT_NAME}_cmd ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
 target_link_libraries(${PROJECT_NAME}_cmd
  ${catkin_LIBRARIES}
  ${PROJECT_NAME}_data_loader
@@ -82,6 +77,12 @@ target_link_libraries(${PROJECT_NAME}_cmd
 #############
 ## Testing ##
 #############
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest_gtest(${PROJECT_NAME}_target_loader_utest test/target_loader.test test/target_loader_utest.cpp)
+  target_link_libraries(${PROJECT_NAME}_target_loader_utest ${PROJECT_NAME}_data_loader ${catkin_LIBRARIES})
+endif()
 
 #############
 ## Install ##

--- a/rct_ros_tools/include/rct_ros_tools/exceptions.h
+++ b/rct_ros_tools/include/rct_ros_tools/exceptions.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace rct_ros_tools
+{
+/**
+ * \brief Thrown during errors in loading or parsing data files
+ */
+class BadFileException : public std::runtime_error
+{
+public:
+  BadFileException(const std::string& what) : std::runtime_error(what) {}
+};
+
+} // namespace rct_ros_tools

--- a/rct_ros_tools/include/rct_ros_tools/loader_utils.h
+++ b/rct_ros_tools/include/rct_ros_tools/loader_utils.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <xmlrpcpp/XmlRpcValue.h>
+#include <xmlrpcpp/XmlRpcException.h>
+#include <yaml-cpp/yaml.h>
+#include <ros/console.h>
+
+namespace rct_ros_tools
+{
+
+template<typename T>
+static bool read(XmlRpc::XmlRpcValue& xml, const std::string& key, T& value)
+{
+  if (!xml.hasMember(key)) return false;
+  try {
+    value = static_cast<T>(xml[key]);
+  } catch (const XmlRpc::XmlRpcException& ex) {
+    ROS_ERROR_STREAM(ex.getMessage());
+    return false;
+  }
+  return true;
+}
+
+}

--- a/rct_ros_tools/include/rct_ros_tools/parameter_loaders.h
+++ b/rct_ros_tools/include/rct_ros_tools/parameter_loaders.h
@@ -9,38 +9,6 @@
 
 namespace rct_ros_tools
 {
-
-/**
- * \brief Thrown during errors in loading or parsing data files
- */
-class BadFileException : public std::runtime_error
-{
-public:
-  BadFileException(const std::string& what) : std::runtime_error(what) {}
-};
-
-/**
- * \brief Load a target from a ROS parameter
- * \throws ros::InvalidParameterException
- */
-rct_image_tools::ModifiedCircleGridTarget loadTarget(const ros::NodeHandle& nh, const std::string& key);
-
-/**
- * \brief Load a target from a ROS parameter. Returns false if an error occurs.
- */
-bool loadTarget(const ros::NodeHandle& nh, const std::string& key, rct_image_tools::ModifiedCircleGridTarget& target);
-
-/**
- * \brief Load a target from a YAML file
- * \throws rct_ros_tools::BadFileException
- */
-rct_image_tools::ModifiedCircleGridTarget loadTarget(const std::string& path);
-
-/**
- * \brief Load a target from a YAML file. Returns false if an error occurs.
- */
-bool loadTarget(const std::string& path, rct_image_tools::ModifiedCircleGridTarget& target);
-
 /**
  * \brief Load camera intrinsics from a ROS parameter
  * \throws ros::InvalidParameterException

--- a/rct_ros_tools/include/rct_ros_tools/target_loaders.h
+++ b/rct_ros_tools/include/rct_ros_tools/target_loaders.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <ros/node_handle.h>
+#include <string>
+
+namespace rct_ros_tools
+{
+template <typename TargetT>
+struct TargetLoader
+{
+  /**
+   * \brief Load a target from a ROS parameter
+   * \throws ros::InvalidParameterException
+   */
+  static TargetT load(const ros::NodeHandle& nh, const std::string& key);
+
+  /**
+   * \brief Load a target from a ROS parameter. Returns false if an error occurs.
+   */
+  static bool load(const ros::NodeHandle& nh, const std::string& key, TargetT& target);
+
+  /**
+   * \brief Load a target from a YAML file
+   * \throws rct_ros_tools::BadFileException
+   */
+  static TargetT load(const std::string& path);
+
+  /**
+   * \brief Load a target from a YAML file. Returns false if an error occurs.
+   */
+  static bool load(const std::string& path, TargetT& target);
+};
+
+} // namespace rct_ros_tools

--- a/rct_ros_tools/src/command_line_cal.cpp
+++ b/rct_ros_tools/src/command_line_cal.cpp
@@ -1,6 +1,7 @@
 #include <ros/ros.h>
 #include <rct_ros_tools/data_set.h>
 #include <rct_ros_tools/parameter_loaders.h>
+#include <rct_ros_tools/target_loaders.h>
 
 #include <tf2_ros/transform_listener.h>
 #include <opencv2/highgui.hpp>
@@ -223,8 +224,13 @@ int main(int argc, char** argv)
   if (!get(pnh, "base_frame", config.base_frame)) return 1;
   if (!get(pnh, "tool_frame", config.tool_frame)) return 1;
   if (!get(pnh, "image_topic", config.image_topic)) return 1;
-  if (!get(pnh, "save_dir", config.save_dir)) return 1;
-  if (!rct_ros_tools::loadTarget(pnh, "target_definition", config.target))
+  if (!get(pnh, "save_dir", config.save_dir))
+    return 1;
+
+  using namespace rct_ros_tools;
+  using namespace rct_image_tools;
+
+  if (!TargetLoader<ModifiedCircleGridTarget>::load(pnh, "target_definition", config.target))
   {
     ROS_ERROR_STREAM("Must provide parameters to load target!");
     return 1;

--- a/rct_ros_tools/src/data_loader/modified_circle_grid_target_loader.cpp
+++ b/rct_ros_tools/src/data_loader/modified_circle_grid_target_loader.cpp
@@ -1,0 +1,72 @@
+#include <rct_ros_tools/exceptions.h>
+#include <rct_ros_tools/loader_utils.h>
+#include <rct_ros_tools/target_loaders.h>
+#include <rct_image_tools/modified_circle_grid_target.h>
+
+namespace rct_ros_tools
+{
+template<>
+rct_image_tools::ModifiedCircleGridTarget TargetLoader<rct_image_tools::ModifiedCircleGridTarget>::load(const ros::NodeHandle& nh, const std::string& key)
+{
+  XmlRpc::XmlRpcValue xml;
+  if (!nh.getParam(key, xml)) throw ros::InvalidParameterException(key);
+
+  int rows = 0;
+  int cols = 0;
+  double spacing = 0.0;
+
+  if (!read(xml, "rows", rows)) throw ros::InvalidParameterException(key + "/rows");
+  if (!read(xml, "cols", cols)) throw ros::InvalidParameterException(key + "/cols");
+  if (!read(xml, "spacing", spacing)) throw ros::InvalidParameterException(key + "/spacing");
+
+  return rct_image_tools::ModifiedCircleGridTarget(rows, cols, spacing);
+}
+
+template<>
+bool TargetLoader<rct_image_tools::ModifiedCircleGridTarget>::load(const ros::NodeHandle& nh, const std::string& key, rct_image_tools::ModifiedCircleGridTarget& target)
+{
+  try
+  {
+    target = load(nh, key);
+  }
+  catch (ros::InvalidParameterException &ex)
+  {
+    ROS_ERROR_STREAM("Failed to load target parameter: " << ex.what());
+    return false;
+  }
+  return true;
+}
+
+template<>
+rct_image_tools::ModifiedCircleGridTarget TargetLoader<rct_image_tools::ModifiedCircleGridTarget>::load(const std::string &path)
+{
+  try
+  {
+    YAML::Node n = YAML::LoadFile(path);
+    int rows = n["target_definition"]["rows"].as<int>();
+    int cols = n["target_definition"]["cols"].as<int>();
+    double spacing = n["target_definition"]["spacing"].as<double>(); // (meters between dot centers)
+    return rct_image_tools::ModifiedCircleGridTarget(rows, cols, spacing);
+  }
+  catch (YAML::Exception &ex)
+  {
+    throw BadFileException(std::string("YAML failure: ") + ex.what());
+  }
+}
+
+template<>
+bool TargetLoader<rct_image_tools::ModifiedCircleGridTarget>::load(const std::string& path, rct_image_tools::ModifiedCircleGridTarget& target)
+{
+  try
+  {
+    target = load(path);
+  }
+  catch (ros::InvalidParameterException &ex)
+  {
+    ROS_ERROR_STREAM("Failed to load target from file: " << ex.what());
+    return false;
+  }
+  return true;
+}
+
+} // namespace rct_ros_tools

--- a/rct_ros_tools/src/data_loader/parameter_loaders.cpp
+++ b/rct_ros_tools/src/data_loader/parameter_loaders.cpp
@@ -1,82 +1,10 @@
 #include "rct_ros_tools/parameter_loaders.h"
-#include <xmlrpcpp/XmlRpcException.h>
-#include <yaml-cpp/yaml.h>
+#include <rct_ros_tools/loader_utils.h>
+#include <rct_ros_tools/exceptions.h>
 
-template<typename T>
-static bool read(XmlRpc::XmlRpcValue& xml, const std::string& key, T& value)
+namespace rct_ros_tools
 {
-  if (!xml.hasMember(key)) return false;
-  try {
-    value = static_cast<T>(xml[key]);
-  } catch (const XmlRpc::XmlRpcException& ex) {
-    ROS_ERROR_STREAM(ex.getMessage());
-    return false;
-  }
-  return true;
-}
-
-rct_image_tools::ModifiedCircleGridTarget rct_ros_tools::loadTarget(const ros::NodeHandle& nh, const std::string& key)
-{
-  XmlRpc::XmlRpcValue xml;
-  if (!nh.getParam(key, xml)) throw ros::InvalidParameterException(key);
-
-  int rows = 0;
-  int cols = 0;
-  double spacing = 0.0;
-
-  if (!read(xml, "rows", rows)) throw ros::InvalidParameterException(key + "/rows");
-  if (!read(xml, "cols", cols)) throw ros::InvalidParameterException(key + "/cols");
-  if (!read(xml, "spacing", spacing)) throw ros::InvalidParameterException(key + "/spacing");
-
-  return rct_image_tools::ModifiedCircleGridTarget(rows, cols, spacing);
-}
-
-bool rct_ros_tools::loadTarget(const ros::NodeHandle& nh, const std::string& key,
-                               rct_image_tools::ModifiedCircleGridTarget& target)
-{
-  try
-  {
-    target = loadTarget(nh, key);
-  }
-  catch (ros::InvalidParameterException &ex)
-  {
-    ROS_ERROR_STREAM("Failed to load target parameter: " << ex.what());
-    return false;
-  }
-  return true;
-}
-
-rct_image_tools::ModifiedCircleGridTarget rct_ros_tools::loadTarget(const std::string &path)
-{
-  try
-  {
-    YAML::Node n = YAML::LoadFile(path);
-    int rows = n["target_definition"]["rows"].as<int>();
-    int cols = n["target_definition"]["cols"].as<int>();
-    double spacing = n["target_definition"]["spacing"].as<double>(); // (meters between dot centers)
-    return rct_image_tools::ModifiedCircleGridTarget(rows, cols, spacing);
-  }
-  catch (YAML::Exception &ex)
-  {
-    throw BadFileException(std::string("YAML failure: ") + ex.what());
-  }
-}
-
-bool rct_ros_tools::loadTarget(const std::string& path, rct_image_tools::ModifiedCircleGridTarget& target)
-{
-  try
-  {
-    target = loadTarget(path);
-  }
-  catch (ros::InvalidParameterException &ex)
-  {
-    ROS_ERROR_STREAM("Failed to load target from file: " << ex.what());
-    return false;
-  }
-  return true;
-}
-
-rct_optimizations::CameraIntrinsics rct_ros_tools::loadIntrinsics(const ros::NodeHandle &nh, const std::string &key)
+rct_optimizations::CameraIntrinsics loadIntrinsics(const ros::NodeHandle &nh, const std::string &key)
 {
   XmlRpc::XmlRpcValue xml;
   if (!nh.getParam(key, xml)) throw ros::InvalidParameterException(key);
@@ -90,8 +18,8 @@ rct_optimizations::CameraIntrinsics rct_ros_tools::loadIntrinsics(const ros::Nod
   return intr;
 }
 
-bool rct_ros_tools::loadIntrinsics(const ros::NodeHandle& nh, const std::string& key,
-                                  rct_optimizations::CameraIntrinsics& intr)
+bool loadIntrinsics(const ros::NodeHandle& nh, const std::string& key,
+                                   rct_optimizations::CameraIntrinsics& intr)
 {
   try
   {
@@ -105,7 +33,7 @@ bool rct_ros_tools::loadIntrinsics(const ros::NodeHandle& nh, const std::string&
   return true;
 }
 
-rct_optimizations::CameraIntrinsics rct_ros_tools::loadIntrinsics(const std::string& path)
+rct_optimizations::CameraIntrinsics loadIntrinsics(const std::string& path)
 {
   try
   {
@@ -124,7 +52,7 @@ rct_optimizations::CameraIntrinsics rct_ros_tools::loadIntrinsics(const std::str
   }
 }
 
-bool rct_ros_tools::loadIntrinsics(const std::string& path, rct_optimizations::CameraIntrinsics& intrinsics)
+bool loadIntrinsics(const std::string& path, rct_optimizations::CameraIntrinsics& intrinsics)
 {
   try
   {
@@ -138,7 +66,7 @@ bool rct_ros_tools::loadIntrinsics(const std::string& path, rct_optimizations::C
   return true;
 }
 
-Eigen::Isometry3d rct_ros_tools::loadPose(const ros::NodeHandle &nh, const std::string &key)
+Eigen::Isometry3d loadPose(const ros::NodeHandle &nh, const std::string &key)
 {
   XmlRpc::XmlRpcValue xml;
   if (!nh.getParam(key, xml)) throw ros::InvalidParameterException(key);
@@ -158,7 +86,7 @@ Eigen::Isometry3d rct_ros_tools::loadPose(const ros::NodeHandle &nh, const std::
   return pose;
 }
 
-bool rct_ros_tools::loadPose(const ros::NodeHandle& nh, const std::string& key, Eigen::Isometry3d& pose)
+bool loadPose(const ros::NodeHandle& nh, const std::string& key, Eigen::Isometry3d& pose)
 {
   try
   {
@@ -172,7 +100,7 @@ bool rct_ros_tools::loadPose(const ros::NodeHandle& nh, const std::string& key, 
   return true;
 }
 
-Eigen::Isometry3d rct_ros_tools::loadPose(const std::string& path)
+Eigen::Isometry3d loadPose(const std::string& path)
 {
   try
   {
@@ -198,7 +126,7 @@ Eigen::Isometry3d rct_ros_tools::loadPose(const std::string& path)
   }
 }
 
-bool rct_ros_tools::loadPose(const std::string& path, Eigen::Isometry3d& pose)
+bool loadPose(const std::string& path, Eigen::Isometry3d& pose)
 {
   try
   {
@@ -211,3 +139,6 @@ bool rct_ros_tools::loadPose(const std::string& path, Eigen::Isometry3d& pose)
   }
   return true;
 }
+
+} // namespace rct_ros_tools
+

--- a/rct_ros_tools/test/modified_circle_grid_target.yaml
+++ b/rct_ros_tools/test/modified_circle_grid_target.yaml
@@ -1,0 +1,4 @@
+target_definition:
+  rows: 7
+  cols: 5
+  spacing: 0.025

--- a/rct_ros_tools/test/target_loader.test
+++ b/rct_ros_tools/test/target_loader.test
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="target_file" default="$(find rct_ros_tools)/test/modified_circle_grid_target.yaml"/>
+  <test test-name="target_loader_utest" pkg="rct_ros_tools" type="rct_ros_tools_target_loader_utest">
+    <rosparam command="load" file="$(arg target_file)"/>
+    <param name="target_file" value="$(arg target_file)" />
+  </test>
+</launch>

--- a/rct_ros_tools/test/target_loader_utest.cpp
+++ b/rct_ros_tools/test/target_loader_utest.cpp
@@ -66,7 +66,7 @@ TYPED_TEST(TargetLoaderTest, test)
 
 int main(int argc, char** argv)
 {
-  testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "target_loader_utest");
   return RUN_ALL_TESTS();
 }

--- a/rct_ros_tools/test/target_loader_utest.cpp
+++ b/rct_ros_tools/test/target_loader_utest.cpp
@@ -1,0 +1,72 @@
+#include <rct_ros_tools/target_loaders.h>
+#include <rct_image_tools/modified_circle_grid_target.h>
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+const static std::string TARGET_PARAM = "target_definition";
+const static std::string TARGET_FILENAME_PARAM = "target_file";
+
+template <typename T>
+class TargetLoaderTest : public ::testing::Test
+{
+public:
+  using ::testing::Test::Test;
+
+  T create();
+
+  bool equals(const T& lhs, const T& rhs);
+};
+
+template <>
+rct_image_tools::ModifiedCircleGridTarget TargetLoaderTest<rct_image_tools::ModifiedCircleGridTarget>::create()
+{
+  return rct_image_tools::ModifiedCircleGridTarget(7, 5, 0.025);
+}
+
+using Implementations = ::testing::Types<rct_image_tools::ModifiedCircleGridTarget>;
+
+TYPED_TEST_CASE(TargetLoaderTest, Implementations);
+
+TYPED_TEST(TargetLoaderTest, test)
+{
+  ros::NodeHandle nh("~");
+  TypeParam nominal_target = this->create();
+  std::string filename;
+  ASSERT_TRUE(nh.getParam(TARGET_FILENAME_PARAM, filename));
+
+  // Method 1 (From ROS parameter, throwing)
+  {
+    TypeParam target;
+    EXPECT_NO_THROW(target = rct_ros_tools::TargetLoader<TypeParam>::load(nh, "target_definition"));
+    EXPECT_EQ(target, nominal_target);
+  }
+
+  // Method 2 (From ROS parameter, non-throwing
+  {
+    TypeParam target;
+    EXPECT_TRUE(rct_ros_tools::TargetLoader<TypeParam>::load(nh, "target_definition", target));
+    EXPECT_EQ(target, nominal_target);
+  }
+
+  // Method 3 (From file, throwing)
+  {
+    TypeParam target;
+    EXPECT_NO_THROW(target = rct_ros_tools::TargetLoader<TypeParam>::load(filename));
+    EXPECT_EQ(target, nominal_target);
+  }
+
+  // Method 4 (From file, non-throwing)
+  {
+    TypeParam target;
+    EXPECT_TRUE(rct_ros_tools::TargetLoader<TypeParam>::load(filename, target));
+    EXPECT_EQ(target, nominal_target);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "target_loader_utest");
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR revises the functions for loading a target definition from YAML file or string path in order to support loading different types of targets (specifically ChArUco and ArUco grid targets). 

In order to have the functions with the same parameters (i.e. ROS node handles, strings, etc.) but return a different datatype (i.e. modified circle grid target, ChArUco grid target), I had to create a template struct that is specializable based on the target type.

@schornakj can you review?