### PR TITLE
Fixes to support Ubuntu 20.04 LTS and OpenCV 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,16 @@ jobs:
       fail-fast: false
       matrix:
         env:
+          - {BADGE: focal,
+             OS_NAME: ubuntu,
+             OS_CODE_NAME: focal,
+             ROS_DISTRO: noetic,
+             ROS_REPO: main,
+             ADDITIONAL_DEBS: git,
+             VERBOSE_TESTS: true,
+             TARGET_CMAKE_ARGS: "-DRCT_BUILD_TESTS=ON",
+             CTEST_OUTPUT_ON_FAILURE: true,
+             AFTER_SCRIPT: "cd $target_ws/build/rct_optimizations && ctest -V && cd $target_ws/build/rct_image_tools && ctest -V"}
           - {BADGE: bionic,
              OS_NAME: ubuntu,
              OS_CODE_NAME: bionic,

--- a/rct_examples/src/tools/noise_qualification_2d.cpp
+++ b/rct_examples/src/tools/noise_qualification_2d.cpp
@@ -1,4 +1,5 @@
-#include <opencv/cv.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/highgui.hpp>
 #include <rct_image_tools/image_observation_finder.h>
 #include <rct_optimizations/validation/noise_qualification.h>
 #include "rct_ros_tools/data_set.h"

--- a/rct_image_tools/src/rct_image_tools/circle_detector.cpp
+++ b/rct_image_tools/src/rct_image_tools/circle_detector.cpp
@@ -80,12 +80,12 @@ DetectionResult findCircles(const cv::Mat& image, const double threshold,
 
   // Get the contours of the image
   std::vector<std::vector<cv::Point>> contours;
-  cv::findContours(binarized_image, contours, CV_RETR_LIST, CV_CHAIN_APPROX_NONE);
+  cv::findContours(binarized_image, contours, cv::RETR_LIST, cv::CHAIN_APPROX_NONE);
 
   // Debug
   cv::Mat debug_img;
-  cv::cvtColor(binarized_image, debug_img, CV_GRAY2RGB);
-  const CvScalar color(255, 0, 0);
+  cv::cvtColor(binarized_image, debug_img, cv::COLOR_GRAY2RGB);
+  const cv::Scalar color(255, 0, 0);
 
   // Loop on all contours
   DetectionResult result;
@@ -363,7 +363,7 @@ void CircleDetector::detect(cv::InputArray input, std::vector<cv::KeyPoint>& key
   cv::Mat grayscale_image;
 
   if (image.channels() == 3)
-    cv::cvtColor(image, grayscale_image, CV_BGR2GRAY);
+    cv::cvtColor(image, grayscale_image, cv::COLOR_BGR2GRAY);
   else
     grayscale_image = image;
 
@@ -386,7 +386,7 @@ cv::Mat CircleDetector::drawDetectedCircles(const cv::Mat& image)
 {
   cv::Mat grayscale_image;
   if (image.channels() == 3)
-    cv::cvtColor(image, grayscale_image, CV_BGR2GRAY);
+    cv::cvtColor(image, grayscale_image, cv::COLOR_BGR2GRAY);
   else
     grayscale_image = image;
 

--- a/rct_image_tools/src/rct_image_tools/image_observation_finder.cpp
+++ b/rct_image_tools/src/rct_image_tools/image_observation_finder.cpp
@@ -4,24 +4,18 @@
 
 using ObservationPoints = std::vector<cv::Point2d>;
 
-static void drawPointLabel(const std::string& label, const cv::Point2d& position, const CvScalar& color, cv::Mat& image)
+static void drawPointLabel(const std::string& label, const cv::Point2d& position, const cv::Scalar& color, cv::Mat& image)
 {
-  CvFont font;
-  cvInitFont(&font, CV_FONT_HERSHEY_SIMPLEX, 0.5, 0.5);
   const double font_scale = 0.75;
   const int line_thickness = 2;
 
-  CvSize label_size;
-  int label_baseline;
-  cvGetTextSize(label.c_str(), &font, &label_size, &label_baseline);
-
-  cv::Point label_origin = cv::Point(position.x, position.y);
+  cv::Point label_origin = cv::Point(static_cast<int>(position.x), static_cast<int>(position.y));
 
   cv::putText(image, label, label_origin, cv::FONT_HERSHEY_SIMPLEX, font_scale, color, line_thickness);
 
   // Draw dot
-  const int RADIUS = 5.0;
-  cv::circle(image, position, RADIUS, color, -1);
+  const int radius = 5.0;
+  cv::circle(image, position, radius, color, -1);
 }
 
 static cv::Mat renderObservations(const cv::Mat& input, const ObservationPoints& observation_points,
@@ -32,7 +26,7 @@ static cv::Mat renderObservations(const cv::Mat& input, const ObservationPoints&
 
   if (!observation_points.empty())
   {
-    cv::Size pattern_size(target.cols, target.rows);
+    cv::Size pattern_size(static_cast<int>(target.cols), static_cast<int>(target.rows));
 
     cv::Mat center_image = cv::Mat(observation_points);
     cv::Mat center_converted;
@@ -40,10 +34,10 @@ static cv::Mat renderObservations(const cv::Mat& input, const ObservationPoints&
     cv::drawChessboardCorners(output_image, pattern_size, center_converted, true);
 
     // Draw point labels // TODO
-    drawPointLabel("First Point", observation_points[0], CvScalar(0, 255, 0), output_image);
-    drawPointLabel("Origin", observation_points[target.rows * target.cols - target.cols], CvScalar(255, 0, 0),
+    drawPointLabel("First Point", observation_points[0], cv::Scalar(0, 255, 0), output_image);
+    drawPointLabel("Origin", observation_points[target.rows * target.cols - target.cols], cv::Scalar(255, 0, 0),
                    output_image);
-    drawPointLabel("Last Point", observation_points[observation_points.size() - 1], CvScalar(0, 0, 255), output_image);
+    drawPointLabel("Last Point", observation_points[observation_points.size() - 1], cv::Scalar(0, 0, 255), output_image);
   }
 
   return output_image;

--- a/rct_ros_tools/CMakeLists.txt
+++ b/rct_ros_tools/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(catkin REQUIRED COMPONENTS
   cv_bridge
   image_transport
   eigen_conversions
+  std_srvs
 )
 
 # This package only provides examples. It does not export any tools.
@@ -43,6 +44,7 @@ catkin_package(
     cv_bridge
     image_transport
     eigen_conversions
+    std_srvs
 )
 
 ###########

--- a/rct_ros_tools/package.xml
+++ b/rct_ros_tools/package.xml
@@ -16,6 +16,7 @@
   <depend>image_transport</depend>
   <depend>rct_image_tools</depend>
   <depend>roscpp</depend>
+  <depend>std_srvs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
 

--- a/rct_ros_tools/src/command_line_cal.cpp
+++ b/rct_ros_tools/src/command_line_cal.cpp
@@ -76,7 +76,7 @@ public:
         cv_bridge::CvImagePtr temp_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::MONO16);
 
         cv::Mat img_conv;
-        cv::cvtColor(temp_ptr->image, img_conv, CV_GRAY2BGR);
+        cv::cvtColor(temp_ptr->image, img_conv, cv::COLOR_GRAY2BGR);
         img_conv.convertTo(img_conv, CV_8UC1);
         cv_ptr = cv_bridge::CvImagePtr(new cv_bridge::CvImage(temp_ptr->header, sensor_msgs::image_encodings::BGR8, img_conv));
       }

--- a/rct_ros_tools/src/data_loader/data_set.cpp
+++ b/rct_ros_tools/src/data_loader/data_set.cpp
@@ -24,7 +24,7 @@ static std::string combine(const std::string& dir, const std::string& rel_path)
 
 cv::Mat rct_ros_tools::readImageOpenCV(const std::string& path)
 {
-  cv::Mat image = cv::imread(path, cv::IMREAD_COLOR); // TODO: Is CV_LOAD_IMAGE_COLOR needed?
+  cv::Mat image = cv::imread(path, cv::IMREAD_COLOR);
   if (image.data == NULL)
   {
     ROS_ERROR("File failed to load or does not exist: %s", path.c_str());

--- a/rct_ros_tools/src/data_loader/data_set.cpp
+++ b/rct_ros_tools/src/data_loader/data_set.cpp
@@ -24,7 +24,7 @@ static std::string combine(const std::string& dir, const std::string& rel_path)
 
 cv::Mat rct_ros_tools::readImageOpenCV(const std::string& path)
 {
-  cv::Mat image = cv::imread(path, CV_LOAD_IMAGE_COLOR); // TODO: Is CV_LOAD_IMAGE_COLOR needed?
+  cv::Mat image = cv::imread(path, cv::IMREAD_COLOR); // TODO: Is CV_LOAD_IMAGE_COLOR needed?
   if (image.data == NULL)
   {
     ROS_ERROR("File failed to load or does not exist: %s", path.c_str());


### PR DESCRIPTION
- OpenCV 4 is the standard OpenCV version distributed by Canonical for Ubuntu 20.04 LTS (aka Focal). One important change is that OpenCV 4 removes the old C API, so we need to fix some places where we use now-deleted headers, enums, and types.
- This also adds a CI pipeline that builds and tests this repo using ROS Noetic.
- There was a missing dependency on the `std_srvs` ROS package, so I added that as well.