### PR TITLE
Add explicit Boost dependency

### DIFF
--- a/rct_image_tools/CMakeLists.txt
+++ b/rct_image_tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(rct_image_tools VERSION 0.1.0 LANGUAGES CXX)
 
+find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(rct_common REQUIRED)
@@ -31,6 +32,9 @@ target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
+  ${Boost_INCLUDE_DIRS}
+)
 target_link_libraries(${PROJECT_NAME} PUBLIC
   opencv_core
   opencv_aruco
@@ -38,6 +42,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   opencv_imgproc
   opencv_highgui
   yaml-cpp
+  ${Boost_LIBRARIES}
   Eigen3::Eigen
   rct::rct_optimizations
 )

--- a/rct_image_tools/CMakeLists.txt
+++ b/rct_image_tools/CMakeLists.txt
@@ -36,13 +36,13 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
   ${Boost_INCLUDE_DIRS}
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${Boost_LIBRARIES}
   opencv_core
   opencv_aruco
   opencv_features2d
   opencv_imgproc
   opencv_highgui
   yaml-cpp
-  ${Boost_LIBRARIES}
   Eigen3::Eigen
   rct::rct_optimizations
 )

--- a/rct_image_tools/package.xml
+++ b/rct_image_tools/package.xml
@@ -8,6 +8,7 @@
 
   <license>Apache 2.0</license>
 
+  <depend>boost</depend>
   <depend>rct_common</depend>
   <depend>rct_optimizations</depend>
   <depend>yaml-cpp</depend>

--- a/rct_optimizations/CMakeLists.txt
+++ b/rct_optimizations/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 project(rct_optimizations VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(rct_common REQUIRED)
+find_package(Boost REQUIRED)
 find_package(Ceres REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
@@ -38,9 +39,11 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
+  ${Boost_INCLUDE_DIRS}
   ${CERES_INCLUDE_DIRS}
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${Boost_LIBRARIES}
   ${CERES_LIBRARIES}
 )
 

--- a/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
+++ b/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
@@ -3,6 +3,7 @@
 
 #include <rct_optimizations/covariance_types.h>
 #include "rct_optimizations/types.h"
+#include "boost/optional.hpp"
 
 namespace rct_optimizations
 {

--- a/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
+++ b/rct_optimizations/include/rct_optimizations/experimental/camera_intrinsic.h
@@ -3,7 +3,6 @@
 
 #include <rct_optimizations/covariance_types.h>
 #include "rct_optimizations/types.h"
-#include "boost/optional.hpp"
 
 namespace rct_optimizations
 {

--- a/rct_optimizations/package.xml
+++ b/rct_optimizations/package.xml
@@ -15,7 +15,6 @@
   <author email="clewis@swri.org">Chris Lewis</author>
 
   <license>Apache 2.0</license>
-
   <depend>libceres-dev</depend>
   <depend>rct_common</depend>
 

--- a/rct_optimizations/package.xml
+++ b/rct_optimizations/package.xml
@@ -15,6 +15,8 @@
   <author email="clewis@swri.org">Chris Lewis</author>
 
   <license>Apache 2.0</license>
+
+  <depend>boost</depend>
   <depend>libceres-dev</depend>
   <depend>rct_common</depend>
 


### PR DESCRIPTION
Depends on #85 

ROS2 no longer depends on Boost, since many of the features that ROS1 was using like `boost::shared_ptr` have been integrated into the C++ standard library. Our `rct_image_tools` package uses some Boost features, specifically `boost::optional`, so it fails to build in ROS2.

A quick fix is to explicitly depend on, find, and link against Boost in `rct_image_tools`.

A longer-term fix would be to minimize our use of Boost in general. There is now a `std::optional` in C++17, but it might be better to redesign the functions that return optionals to throw exceptions instead.