### PR TITLE
Add alternative constructor for ArUcoGridTarget

### DIFF
--- a/rct_image_tools/include/rct_image_tools/aruco_grid_target.h
+++ b/rct_image_tools/include/rct_image_tools/aruco_grid_target.h
@@ -43,26 +43,4 @@ struct ArucoGridTarget : Target
   /** @brief Map of 3D ArUco tag corners with corresponding IDs */
   std::map<int, std::vector<Eigen::Vector3d>> points;
 };
-
-/**
- * @brief For a given ArUco GridBoard, create a map of marker corner coordinates keyed to marker IDs.
- * @param board - ArUco GridBoard to use when generating the map
- * @return Resulting map. Keys are the IDs for the ArUco markers in the board. Values are vectors containing the four board-relative coordinates
- * for the corners of the marker.
- */
-static std::map<int, std::vector<Eigen::Vector3d>> mapArucoIdsToObjPts(const cv::Ptr<cv::aruco::GridBoard> &board)
-{
-  std::map<int, std::vector<Eigen::Vector3d>> map_ids_to_corners;
-  for (std::size_t i = 0; i < board->ids.size(); i++)
-  {
-    std::vector<Eigen::Vector3d> obj_pts(board->objPoints[i].size());
-    std::transform(
-          board->objPoints[i].begin(), board->objPoints[i].end(), obj_pts.begin(),
-          [](const cv::Point3f& o) -> Eigen::Vector3d { return Eigen::Vector3f(o.x, o.y, o.z).cast<double>(); });
-
-    map_ids_to_corners.insert(std::make_pair(board->ids[i], obj_pts));
-  }
-  return map_ids_to_corners;
-}
-
 } // namespace rct_image_tools

--- a/rct_image_tools/include/rct_image_tools/aruco_grid_target.h
+++ b/rct_image_tools/include/rct_image_tools/aruco_grid_target.h
@@ -22,6 +22,12 @@ struct ArucoGridTarget : Target
   ArucoGridTarget(const int rows, const int cols, const float aruco_marker_dim, const float marker_gap,
                   const int dictionary_id = cv::aruco::DICT_6X6_250);
 
+  /**
+   * @brief Constructor
+   * @param board_in - OpenCV ArUco GridBoard object defining rows, columns, marker size, and marker spacing
+   */
+  ArucoGridTarget(const cv::Ptr<cv::aruco::GridBoard>& board_in);
+
   bool operator==(const ArucoGridTarget& other) const;
 
   /**
@@ -37,5 +43,26 @@ struct ArucoGridTarget : Target
   /** @brief Map of 3D ArUco tag corners with corresponding IDs */
   std::map<int, std::vector<Eigen::Vector3d>> points;
 };
+
+/**
+ * @brief For a given ArUco GridBoard, create a map of marker corner coordinates keyed to marker IDs.
+ * @param board - ArUco GridBoard to use when generating the map
+ * @return Resulting map. Keys are the IDs for the ArUco markers in the board. Values are vectors containing the four board-relative coordinates
+ * for the corners of the marker.
+ */
+static std::map<int, std::vector<Eigen::Vector3d>> mapArucoIdsToObjPts(const cv::Ptr<cv::aruco::GridBoard> &board)
+{
+  std::map<int, std::vector<Eigen::Vector3d>> map_ids_to_corners;
+  for (std::size_t i = 0; i < board->ids.size(); i++)
+  {
+    std::vector<Eigen::Vector3d> obj_pts(board->objPoints[i].size());
+    std::transform(
+          board->objPoints[i].begin(), board->objPoints[i].end(), obj_pts.begin(),
+          [](const cv::Point3f& o) -> Eigen::Vector3d { return Eigen::Vector3f(o.x, o.y, o.z).cast<double>(); });
+
+    map_ids_to_corners.insert(std::make_pair(board->ids[i], obj_pts));
+  }
+  return map_ids_to_corners;
+}
 
 } // namespace rct_image_tools

--- a/rct_image_tools/src/rct_image_tools/aruco_finder.cpp
+++ b/rct_image_tools/src/rct_image_tools/aruco_finder.cpp
@@ -52,17 +52,4 @@ cv::Mat ArucoGridBoardTargetFinder::drawTargetFeatures(const cv::Mat& image, con
   cv::aruco::drawDetectedMarkers(image, marker_corners, marker_ids);
   return image;
 }
-
-std::map<unsigned, std::vector<Eigen::Vector3d>> mapArucoIdsToObjPts(const cv::Ptr<cv::aruco::GridBoard> &board)
-{
-  std::map<unsigned, std::vector<Eigen::Vector3d>> map_ids_to_corners;
-  for (unsigned i = 0; i < board->ids.size(); i++)
-  {
-    std::vector<Eigen::Vector3d> obj_pts(board->objPoints[i].size());
-    std::transform(board->objPoints[i].begin(), board->objPoints[i].end(), obj_pts.begin(), [](const cv::Point3f& o) {return Eigen::Vector3f(o.x, o.y, o.z).cast<double>(); });
-    map_ids_to_corners.insert(std::make_pair(board->ids[i], obj_pts));
-  }
-  return map_ids_to_corners;
-}
-
 } // namespace rct_image_tools

--- a/rct_image_tools/src/rct_image_tools/aruco_grid_target.cpp
+++ b/rct_image_tools/src/rct_image_tools/aruco_grid_target.cpp
@@ -2,23 +2,17 @@
 
 namespace rct_image_tools
 {
+
 ArucoGridTarget::ArucoGridTarget(const int rows, const int cols, const float aruco_marker_dim, const float marker_gap,
                                  const int dictionary_id)
+  : ArucoGridTarget(cv::aruco::GridBoard::create(cols, rows, aruco_marker_dim, marker_gap, cv::aruco::getPredefinedDictionary(dictionary_id)))
 {
-  cv::Ptr<cv::aruco::Dictionary> dictionary = cv::aruco::getPredefinedDictionary(dictionary_id);
+}
 
-  // Create charuco board object
-  board = cv::aruco::GridBoard::create(cols, rows, aruco_marker_dim, marker_gap, dictionary);
-
-  // Create a map of chessboard intersection IDs and their location on the board
-  for (unsigned i = 0; i < board->ids.size(); i++)
-  {
-    std::vector<Eigen::Vector3d> obj_pts(board->objPoints[i].size());
-    std::transform(
-        board->objPoints[i].begin(), board->objPoints[i].end(), obj_pts.begin(),
-        [](const cv::Point3f& o) -> Eigen::Vector3d { return Eigen::Vector3f(o.x, o.y, o.z).cast<double>(); });
-    points.insert(std::make_pair(board->ids[i], obj_pts));
-  }
+ArucoGridTarget::ArucoGridTarget(const cv::Ptr<cv::aruco::GridBoard>& board_in)
+  : board(board_in)
+  , points(mapArucoIdsToObjPts(board))
+{
 }
 
 bool ArucoGridTarget::operator==(const ArucoGridTarget& other) const

--- a/rct_image_tools/src/rct_image_tools/aruco_grid_target.cpp
+++ b/rct_image_tools/src/rct_image_tools/aruco_grid_target.cpp
@@ -1,8 +1,31 @@
 #include <rct_image_tools/aruco_grid_target.h>
 
+namespace
+{
+/**
+ * @brief For a given ArUco GridBoard, create a map of marker corner coordinates keyed to marker IDs.
+ * @param board - ArUco GridBoard to use when generating the map
+ * @return Resulting map. Keys are the IDs for the ArUco markers in the board. Values are vectors containing the four board-relative coordinates
+ * for the corners of the marker.
+ */
+std::map<int, std::vector<Eigen::Vector3d>> mapArucoIdsToObjPts(const cv::Ptr<cv::aruco::GridBoard> &board)
+{
+  std::map<int, std::vector<Eigen::Vector3d>> map_ids_to_corners;
+  for (std::size_t i = 0; i < board->ids.size(); i++)
+  {
+    std::vector<Eigen::Vector3d> obj_pts(board->objPoints[i].size());
+    std::transform(
+          board->objPoints[i].begin(), board->objPoints[i].end(), obj_pts.begin(),
+          [](const cv::Point3f& o) -> Eigen::Vector3d { return Eigen::Vector3f(o.x, o.y, o.z).cast<double>(); });
+
+    map_ids_to_corners.insert(std::make_pair(board->ids[i], obj_pts));
+  }
+  return map_ids_to_corners;
+}
+}
+
 namespace rct_image_tools
 {
-
 ArucoGridTarget::ArucoGridTarget(const int rows, const int cols, const float aruco_marker_dim, const float marker_gap,
                                  const int dictionary_id)
   : ArucoGridTarget(cv::aruco::GridBoard::create(cols, rows, aruco_marker_dim, marker_gap, cv::aruco::getPredefinedDictionary(dictionary_id)))

--- a/rct_image_tools/test/target_finder_utest.cpp
+++ b/rct_image_tools/test/target_finder_utest.cpp
@@ -172,6 +172,34 @@ public:
   ArucoGridTarget target;
 };
 
+class ArucoFinderPredefinedBoardTest : public TargetFinderTestFixture
+{
+public:
+  ArucoFinderPredefinedBoardTest()
+    : TargetFinderTestFixture()
+    , target(cv::aruco::GridBoard::create(20, 20, 0.035f, 0.010f, cv::aruco::getPredefinedDictionary(cv::aruco::DICT_6X6_1000)))
+  {
+    finder = std::make_shared<ArucoGridBoardTargetFinder>(target);
+  }
+
+  virtual void SetUp() override
+  {
+    filename = std::string(TEST_SUPPORT_DIR) + "aruco.jpg";
+
+    // Expect to see the entire board
+    expected_ids.resize(static_cast<unsigned>(target.board->getGridSize().area()));
+    std::iota(expected_ids.begin(), expected_ids.end(), 0);
+
+    // Set up the homography check correspondence sampler
+    // The stride of the correspondence sampler is 4, since there are 4 corners associated with each unique tag
+    auto grid_size = target.board->getGridSize();
+    corr_sampler = std::make_shared<rct_optimizations::GridCorrespondenceSampler>(grid_size.height, grid_size.width, 4);
+    homography_error_threshold = 3.0;
+  }
+
+  ArucoGridTarget target;
+};
+
 TEST_F(ModifiedCircleGridFinderTest, findTargetFeatures)
 {
   this->runTest();
@@ -193,6 +221,11 @@ TEST_F(OneFeatureCharucoFinderTest, findTargetFeatures)
 }
 
 TEST_F(ArucoFinderTest, findTargetFeatures)
+{
+  this->runTest();
+}
+
+TEST_F(ArucoFinderPredefinedBoardTest, findTargetFeatures)
 {
   this->runTest();
 }


### PR DESCRIPTION
- Add a constructor for `ArUcoGridTarget` that takes a `cv::Ptr<cv::aruco::GridBoard>` as an argument, to allow using externally-defined gridboard objects.
- Refactor constructor to remove duplicated functions that map ArUco marker IDs to marker corner coordinates using the board definition.