### PR TITLE
Fix gtest and add C++14 option

### DIFF
--- a/rct_examples/CMakeLists.txt
+++ b/rct_examples/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(rct_examples)
+set (CMAKE_CXX_STANDARD 14)
 
-add_compile_options(-std=c++11 -Wall -Wextra)
+add_compile_options(-Wall -Wextra)
 
 find_package(rct_optimizations REQUIRED)
 find_package(rct_image_tools REQUIRED)

--- a/rct_optimizations/CMakeLists.txt
+++ b/rct_optimizations/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(rct_optimizations VERSION 0.1.0 LANGUAGES CXX)
+set (CMAKE_CXX_STANDARD 14)
 
 find_package(rct_common REQUIRED)
 find_package(Boost REQUIRED)

--- a/rct_ros_tools/CMakeLists.txt
+++ b/rct_ros_tools/CMakeLists.txt
@@ -89,12 +89,9 @@ target_link_libraries(${PROJECT_NAME}_cmd
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
-  find_package(GTest REQUIRED)
-  add_rostest_gtest(${PROJECT_NAME}_target_loader_utest test/target_loader.test test/target_loader_utest.cpp)
+  catkin_add_gtest(${PROJECT_NAME}_target_loader_utest test/target_loader.test test/target_loader_utest.cpp)
   target_link_libraries(${PROJECT_NAME}_target_loader_utest
     ${PROJECT_NAME}_data_loader
-    GTest::GTest
-    GTest::Main
     ${catkin_LIBRARIES}
   )
 endif()

--- a/rct_ros_tools/package.xml
+++ b/rct_ros_tools/package.xml
@@ -19,5 +19,7 @@
   <depend>std_srvs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
+  <test_depend>rosunit</test_depend>
+
 
 </package>


### PR DESCRIPTION
Fix the gtest issue at : https://github.com/Jmeyer1292/robot_cal_tools/issues/83
Reference : http://docs.ros.org/en/jade/api/catkin/html/howto/format2/gtest_configuration.html 

Add C++14 options, because since Ceres v2.0, C++14 is required

```bash
# source  : http://ceres-solver.org/installation.html
Starting with v2.0 Ceres requires a fully C++14-compliant compiler. In versions <= 1.14, C++11 was an optional requirement.

```