### PR TITLE
Update for Ceres 2.2 and Ubuntu Noble

### DIFF
--- a/rct_common/CMakeLists.txt
+++ b/rct_common/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 find_gtest()
 
 add_library(${PROJECT_NAME} INTERFACE)
-target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 target_include_directories(${PROJECT_NAME} INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                      "$<INSTALL_INTERFACE:include>")
 target_link_libraries(${PROJECT_NAME} INTERFACE Eigen3::Eigen)

--- a/rct_optimizations/CMakeLists.txt
+++ b/rct_optimizations/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(
   # DH Chain Kinematic Calibration
   src/${PROJECT_NAME}/dh_chain.cpp
   src/${PROJECT_NAME}/dh_chain_kinematic_calibration.cpp)
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                   "$<INSTALL_INTERFACE:include>")

--- a/rct_optimizations/include/rct_optimizations/dh_chain_kinematic_calibration.h
+++ b/rct_optimizations/include/rct_optimizations/dh_chain_kinematic_calibration.h
@@ -400,7 +400,7 @@ public:
     T rot_diff = Eigen::Quaternion<T>(camera_to_target_measured_.cast<T>().linear())
                      .angularDistance(Eigen::Quaternion<T>(camera_to_target.linear()));
 
-    residual[3] = ceres::IsNaN(rot_diff) ? T(0.0) : T(orientation_weight_) * rot_diff;
+    residual[3] = ceres::isnan(rot_diff) ? T(0.0) : T(orientation_weight_) * rot_diff;
 
     return true;
   }

--- a/rct_optimizations/include/rct_optimizations/local_parameterization.h
+++ b/rct_optimizations/include/rct_optimizations/local_parameterization.h
@@ -2,7 +2,7 @@
 
 #include <Eigen/Core>
 #include <ceres/problem.h>
-#include <ceres/local_parameterization.h>
+#include <ceres/manifold.h>
 #include <rct_optimizations/types.h>
 
 // Ceres Solver - A fast non-linear least squares minimizer
@@ -126,8 +126,8 @@ void addSubsetParameterization(ceres::Problem& problem, const std::map<const dou
         }
         else
         {
-          ceres::LocalParameterization* lp = new ceres::SubsetParameterization(block_size, mask);
-          problem.SetParameterization(p, lp);
+          ceres::Manifold* lp = new ceres::SubsetManifold(block_size, mask);
+          problem.SetManifold(p, lp);
         }
       }
     }

--- a/rct_optimizations/test/local_parameterization_utest.cpp
+++ b/rct_optimizations/test/local_parameterization_utest.cpp
@@ -40,7 +40,7 @@ TEST(LocalParameterizationTests, SubsetParameterization)
     EXPECT_NO_THROW(addSubsetParameterization(problem, mask));
 
     // Expect there to be no parameterization, but the entire block should be constant
-    EXPECT_EQ(problem.GetParameterization(params.data()), nullptr);
+    EXPECT_EQ(problem.GetManifold(params.data()), nullptr);
     EXPECT_TRUE(problem.IsParameterBlockConstant(params.data()));
   }
 
@@ -51,7 +51,7 @@ TEST(LocalParameterizationTests, SubsetParameterization)
     int bad_idx = params.size() * 2;
     mask[params.data()].insert(mask[params.data()].begin(), { bad_idx, 0, 1, 2 });
     EXPECT_THROW(addSubsetParameterization(problem, mask), OptimizationException);
-    EXPECT_EQ(problem.GetParameterization(params.data()), nullptr);
+    EXPECT_EQ(problem.GetManifold(params.data()), nullptr);
   }
 
   // Empty mask
@@ -59,7 +59,7 @@ TEST(LocalParameterizationTests, SubsetParameterization)
     std::map<const double*, std::vector<int>> mask;
     EXPECT_NO_THROW(addSubsetParameterization(problem, mask));
     // An empty mask should not have added any local parameterization
-    EXPECT_EQ(problem.GetParameterization(params.data()), nullptr);
+    EXPECT_EQ(problem.GetManifold(params.data()), nullptr);
   }
 
   // Hold the zero-th row constant
@@ -73,7 +73,7 @@ TEST(LocalParameterizationTests, SubsetParameterization)
       mask[params.data()].push_back(i * params.rows());
     }
     EXPECT_NO_THROW(addSubsetParameterization(problem, mask));
-    EXPECT_NE(problem.GetParameterization(params.data()), nullptr);
+    EXPECT_NE(problem.GetManifold(params.data()), nullptr);
   }
 
   // Solve the optimization


### PR DESCRIPTION
Hello!

I'm using this project on Ubuntu 24.04, which requires at least Ceres 2.2. These are the changes I needed to add to get the non-ROS part of this repo building (I'm using ROS 2 Jazzy so I haven't looked at the ROS 1 packages in this repo yet to see if they need to change).

- Update uses of some Ceres functions that already were deprecated or soon will be:
  - `IsNaN` -> `isnan`
  - `GetParameterization` -> `GetManifold`
- The minimum C++ version needs to be updated to C++17.

This raises a repo version management question: how should we handle changes that break compatibility with older OS versions? In other projects I've used different branches for each target platform (`focal`, `noble`, etc.). In contrast I think [Tesseract](https://github.com/tesseract-robotics/tesseract) just drops support for older platforms as the tagged release advances.